### PR TITLE
Comment out milestone sync

### DIFF
--- a/src/main/python/githubsync/cli.py
+++ b/src/main/python/githubsync/cli.py
@@ -367,12 +367,13 @@ def synchronize(data, shared_data):
         modified_since=shared_data['modified_since'],
         noop=shared_data['noop'])
 
-    client.sync_milestones(
-        repo,
-        shared_data['milestones'],
-        shared_data['source_repo'],
-        modified_since=shared_data['modified_since'],
-        noop=shared_data['noop'])
+    # temporary
+    # client.sync_milestones(
+    #     repo,
+    #     shared_data['milestones'],
+    #     shared_data['source_repo'],
+    #     modified_since=shared_data['modified_since'],
+    #     noop=shared_data['noop'])
 
 
 def initiate_multiprocess(client, args, blacklist_repos):

--- a/src/unittest/python/test_cli.py
+++ b/src/unittest/python/test_cli.py
@@ -120,12 +120,12 @@ class TestCli(unittest.TestCase):
             'source-repo',
             modified_since='modified-since',
             noop=False)
-        client_mock.sync_milestones.assert_called_once_with(
-            'owner/repo1',
-            ['milestone1', 'milestone2'],
-            'source-repo',
-            modified_since='modified-since',
-            noop=False)
+        # client_mock.sync_milestones.assert_called_once_with(
+        #     'owner/repo1',
+        #     ['milestone1', 'milestone2'],
+        #     'source-repo',
+        #     modified_since='modified-since',
+        #     noop=False)
 
     @patch('githubsync.cli.execute')
     def test__initiate_multiprocess_Should_CallExpected_When_Called(self, execute_patch, *patches):


### PR DESCRIPTION
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

The milestone synchronization didn't work as expected. In investigating the issue; several of the target repos already had a milestone called 'EdgeX Hanoi' which is a different name and more importantly a different milestone number than what the source repo has defined in cd-management. The GitHub API only supports getting and updating a milestone by its milestone number, for milestones GitHub uses the milestone number as the resource identifier.
https://developer.github.com/v3/issues/milestones/#get-a-milestone
https://developer.github.com/v3/issues/milestones/#update-a-milestone

Thus synchronization of milestones is going to require a bit more logic since some of the repos already have milestones created with the same milestone number but for a different name than what the source repo has defined.

For example, in cd-management Hanoi is defined as `milestone/1` but some repos already have `milestone/1` assigned to Geneva or Edinburg or something completely different.  Also, other repos already have a Hanoi milestone but it is called 'EdgeX Hanoi'. We need to standardize on what the milestone name should be and set it in cd-management appropriately, and update the logic to synchronize milestones by name and not by milestone number.
