### PR TITLE
Fix issue with sync milestones

### DIFF
--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ authors = [
 ]
 summary = 'A Python script to synchronize labels for repositories in a GitHub organization'
 url = 'https://github.com/edgexfoundry/cd-management/tree/git-label-sync'
-version = '0.0.1'
+version = '0.0.2'
 default_task = [
     'clean',
     'analyze',

--- a/src/main/python/githubsync/cli.py
+++ b/src/main/python/githubsync/cli.py
@@ -367,13 +367,19 @@ def synchronize(data, shared_data):
         modified_since=shared_data['modified_since'],
         noop=shared_data['noop'])
 
-    # temporary
-    # client.sync_milestones(
-    #     repo,
-    #     shared_data['milestones'],
-    #     shared_data['source_repo'],
-    #     modified_since=shared_data['modified_since'],
-    #     noop=shared_data['noop'])
+    client.sync_milestones(
+        repo,
+        shared_data['milestones'],
+        shared_data['source_repo'],
+        modified_since=shared_data['modified_since'],
+        noop=shared_data['noop'])
+
+
+def check_result(process_data):
+    """ raise exception if any result in process data is exception
+    """
+    if any([isinstance(process.get('result'), Exception) for process in process_data]):
+        raise Exception('one or more processes had errors')
 
 
 def initiate_multiprocess(client, args, blacklist_repos):
@@ -404,11 +410,12 @@ def initiate_multiprocess(client, args, blacklist_repos):
     if args.processes > len(repos):
         args.processes = len(repos)
 
+    process_data = [
+        {'repo': repo} for repo in repos
+    ]
     execute(
         function=synchronize,
-        process_data=[
-            {'repo': repo} for repo in repos
-        ],
+        process_data=process_data,
         shared_data={
             'client': client,
             'source_repo': args.source_repo,
@@ -426,6 +433,8 @@ def initiate_multiprocess(client, args, blacklist_repos):
             'Started:{}'.format(datetime.now().strftime('%m/%d/%Y %H:%M:%S'))
         ],
         screen_layout=get_screen_layout() if args.screen else None)
+
+    check_result(process_data)
 
 
 def set_logging(args):

--- a/src/unittest/python/test_cli.py
+++ b/src/unittest/python/test_cli.py
@@ -26,6 +26,7 @@ from githubsync.cli import validate
 from githubsync.cli import get_client
 from githubsync.cli import get_screen_layout
 from githubsync.cli import synchronize
+from githubsync.cli import check_result
 from githubsync.cli import initiate_multiprocess
 from githubsync.cli import set_logging
 from githubsync.cli import main
@@ -146,6 +147,13 @@ class TestCli(unittest.TestCase):
         blacklist_repos = ['repo2', 'repo3']
         initiate_multiprocess(client_mock, args, blacklist_repos)
         execute_patch.assert_not_called()
+
+    def test__check_result_Should_RaiseException_When_ProcessResultException(self, *patches):
+        process_data = [
+            {}, {}, {}, {'result': ValueError('error')}
+        ]
+        with self.assertRaises(Exception):
+            check_result(process_data)
 
     @patch('githubsync.cli.getenv')
     @patch('githubsync.cli.logging')


### PR DESCRIPTION
This update addresses the issue with the synchronization of milestones. The GitHub API only supports getting and updating of milestones via their milestone number (not milestone title). https://github.com/edgexfoundry/cd-management/issues/33  

The pseudo-code below describes the updated logic for synchronizing milestones:

This update also updates exception handling so that the main process fails if any of the spawned processes have failures.

**Pseudo-Code**
```
for milestone_to_sync in milestones_to_sync
    if milestone_to_sync exists in the target repo
        if milestone on source repo has been modified since date provided
            get the milestone id for the milestone_to_sync from the target repo
             update the milestone in the target repo using its milestone id
    else
        create milestone on target repo
```

**Functional Testing**
I functionally tested using repos in my user account:
source repo: https://github.com/soda480/test_us6379-09
target repos: `test_us6379-01` - `test_us6379-10` 

I tested the following conditions:
- no milestones exist in the target repo 
- milestones exist in target repo that are not in the source repo
- milestones exist in target repo that are in the source repo but with different milestone ids
- milestones exist in target repo that are in the source repo but have different values for their properties 
- milestones exist in target repo that are in the source repo with same property values

**Unit Testing**
Unit tests for all added/;updated logic have been added. 100% code coverage maintained.

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>