### PR TITLE
release(geneva dot): Release Go Device Services

### DIFF
--- a/release/device-camera-go.yaml
+++ b/release/device-camera-go.yaml
@@ -1,6 +1,6 @@
 ---
 name: 'device-camera-go'
-version: '1.1.0'
+version: '1.1.1'
 releaseName: 'geneva'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-camera-go.git'

--- a/release/device-modbus-go.yaml
+++ b/release/device-modbus-go.yaml
@@ -1,11 +1,11 @@
 ---
 name: 'device-modbus-go'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'geneva'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-modbus-go.git'
-gitTag: false
-dockerImages: false
+gitTag: true
+dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-modbus-go
     destination:
@@ -17,7 +17,5 @@ docker:
       - docker.io/edgexfoundry/docker-device-modbus-go-arm64
 snap: true
 snapChannels:
-  - channel: 'latest/stable'
   - channel: 'latest/beta'
   - channel: 'latest/candidate'
-  - channel: 'geneva/stable'

--- a/release/device-mqtt-go.yaml
+++ b/release/device-mqtt-go.yaml
@@ -1,11 +1,11 @@
 ---
 name: 'device-mqtt-go'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'geneva'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-mqtt-go.git'
-gitTag: false
-dockerImages: false
+gitTag: true
+dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-mqtt-go
     destination:
@@ -17,7 +17,5 @@ docker:
       - docker.io/edgexfoundry/docker-device-mqtt-go-arm64
 snap: true
 snapChannels:
-  - channel: 'latest/stable'
   - channel: 'latest/beta'
   - channel: 'latest/candidate'
-  - channel: 'geneva/stable'

--- a/release/device-random.yaml
+++ b/release/device-random.yaml
@@ -1,6 +1,6 @@
 ---
 name: 'device-random-go'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'geneva'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-random.git'

--- a/release/device-rest-go.yaml
+++ b/release/device-rest-go.yaml
@@ -1,6 +1,6 @@
 ---
 name: 'device-rest-go'
-version: '1.1.0'
+version: '1.1.1'
 releaseName: 'geneva'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-rest-go.git'

--- a/release/device-snmp-go.yaml
+++ b/release/device-snmp-go.yaml
@@ -1,6 +1,6 @@
 ---
 name: 'device-snmp-go'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'geneva'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-snmp-go.git'

--- a/release/device-virtual-go.yaml
+++ b/release/device-virtual-go.yaml
@@ -1,6 +1,6 @@
 ---
 name: 'device-virtual-go'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'geneva'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-virtual-go.git'


### PR DESCRIPTION
 - device-camera-go (v1.1.1)
 - device-modbus-go (v1.2.1)
 - device-mqtt-go (v1.2.1)
 - device-random-go (v1.2.1)
 - device-rest-go (v1.1.1)
 - device-snmp-go (v1.2.1)
 - device-virtual-go (v1.2.1)

Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>