### PR TITLE
release(geneva): Release Device Grove C service (1.2.0) and Testing frameworks (1.2.1)

### DIFF
--- a/release/blackbox-testing.yaml
+++ b/release/blackbox-testing.yaml
@@ -1,8 +1,8 @@
 ---
 name: 'blackbox-testing'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'geneva'
-releaseStream: 'master'
+releaseStream: 'geneva'
 repo: 'https://github.com/edgexfoundry/blackbox-testing.git'
 gitTag: true
 dockerImages: false

--- a/release/device-grove-c.yaml
+++ b/release/device-grove-c.yaml
@@ -1,0 +1,14 @@
+---
+name: 'device-grove-c'
+version: '1.2.0'
+releaseName: 'geneva'
+releaseStream: 'master'
+repo: 'https://github.com/edgexfoundry/device-sdk-c.git'
+gitTag: true
+dockerImages: true
+docker:
+  - image: nexus3.edgexfoundry.org:10004/docker-device-grove-c-arm64
+    destination:
+      - nexus3.edgexfoundry.org:10002/docker-device-grove-c-arm64
+      - docker.io/edgexfoundry/docker-device-grove-c-arm64
+snap: false

--- a/release/edgex-taf.yaml
+++ b/release/edgex-taf.yaml
@@ -1,8 +1,8 @@
 ---
 name: 'edgex-taf'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'geneva'
-releaseStream: 'master'
+releaseStream: 'geneva'
 repo: 'https://github.com/edgexfoundry/edgex-taf.git'
 gitTag: true
 dockerImages: false


### PR DESCRIPTION
Signed-off-by: Lisa Rashidi-Ranjbar <lisa.a.rashidi-ranjbar@intel.com>