### PR TITLE
add new branch to build geneva snap fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,12 +41,12 @@ pipeline {
                     stages {
                         stage('Clone Code') {
                             steps {
-                                git changelog: false, poll: false, url: 'https://github.com/edgexfoundry/edgex-go.git'
+                                git changelog: false, poll: false, branch: 'geneva', url: 'https://github.com/edgexfoundry/edgex-go.git'
                             }
                         }
                         stage('Stage Snap'){
                             steps {
-                                edgeXSnap(jobType: 'stage', snapChannel: 'latest/edge')
+                                edgeXSnap(jobType: 'stage', snapChannel: 'geneva/edge')
                             }
                         }
                     }
@@ -59,12 +59,12 @@ pipeline {
                     stages {
                         stage('Clone Code') {
                             steps {
-                                git changelog: false, poll: false, url: 'https://github.com/edgexfoundry/edgex-go.git'
+                                git changelog: false, poll: false, branch: 'geneva', url: 'https://github.com/edgexfoundry/edgex-go.git'
                             }
                         }
                         stage('Stage Snap'){
                             steps {
-                                edgeXSnap(jobType: 'stage', snapChannel: 'latest/edge')
+                                edgeXSnap(jobType: 'stage', snapChannel: 'geneva/edge')
                             }
                         }
                     }


### PR DESCRIPTION
This branch will build and push the `geneva` based edgex-go codebase to the `geneva/edge` snap channel.

Signed-off-by: Ernesto Ojeda <ernesto.ojeda@intel.com>