### PR TITLE
EdgeX DevOps: Implement ability to prune semver version tags from edgexfoundry repos with a given range.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,16 @@ pipeline {
             name: 'Execute',
             defaultValue: '',
             description: 'Specify --execute to run script in execute mode, leave it blank to run script in NOOP mode.')
+        string(
+            name: 'Version',
+            defaultValue: '',
+            description: 'Specify \'--remove-version <version-range>\' to remove *all* tags within range. \
+                See README for syntax. e.g.\"--remove-version \'<1.0.87\'\"')
+        string(
+            name: 'Include Repositories',
+            defaultValue: '--include edgex-global-pipelines',
+            description: 'Specify \'--include <repo-name>\' to target specific repositories. Leaving this argument \
+                blank will target *all* repos within edgexfoundry.')
     }
     environment {
         GH_TOKEN = credentials('edgex-jenkins-github-personal-access-token')
@@ -43,7 +53,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sh "prune-github-tags --org edgexfoundry --procs 10 ${params.Execute}"
+                        sh "prune-github-tags --org edgexfoundry --procs 10 --report ${params.Execute} ${params.Version} ${params['Include Repositories']}"
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This script queries repos from a specified GitHub organization and remove all old pre-release tags found in the repos. The majority of the repos in the EdgeXFoundry org leverage a semantic versioning tagging convention, over time the need has risen to prune (i.e. remove) older pre-release tags in order to maintain a sanitized set of tags for each repo. For more information regarding semantic versioning refer to the following: https://semver.org/
+This script queries repos from a specified GitHub organization and by default removes all old pre-release tags found in the repos. The majority of the repos in the EdgeXFoundry org leverage a semantic versioning tagging convention, over time the need has risen to prune (i.e. remove) older pre-release tags in order to maintain a sanitized set of tags for each repo. For more information regarding semantic versioning refer to the following: https://semver.org/. Optional functionality also exists to remove specific version ranges following standard semantic versioning rules. e.g. `>=1.0.20,<1.0.50`
 
 ### `prune-github-tags`
 ```bash
@@ -10,6 +10,7 @@ usage: prune-github-tags [-h] [--org ORG] [--user USER]
                          [--exclude-repos EXCLUDE_REPOS]
                          [--include-repos INCLUDE_REPOS] [--report]
                          [--procs PROCESSES] [--screen] [--debug] [--execute]
+                         [--remove-version EXPRESSION]
 
 A Python script that removes old prerelease tags from repos in a GitHub org
 
@@ -29,7 +30,12 @@ optional arguments:
   --debug               display debug messages to stdout
   --execute             execute processing - not setting is same as running in
                         NOOP mode
+  --remove-version      version expression to remove specific version(s)
+                        *including* pre-release tags.
 ```
+
+#### Reference
+For `--remove-version` option syntax refer to [SimpleSpec Syntax Reference](https://python-semanticversion.readthedocs.io/en/latest/reference.html#semantic_version.SimpleSpec)
 
 #### Pseudo-code
 ```Script
@@ -82,4 +88,20 @@ prune-github-tags \
 --include 'device-|go-mod-' \
 --exclude 'go-mod-bootstrap' \
 --screen
+```
+
+remove *all* (released & pre-released) versions before 1.0.50. execute in NOOP mode.
+```bash
+prune-github-tags \
+--org edgexfoundry \
+--include 'edgex-global-pipelines' \
+--remove-version '<1.0.50'
+```
+
+remove *all* (released & pre-released) versions before 1.0.50 and after (inclusive) 1.0.20. execute in NOOP mode.
+```bash
+prune-github-tags \
+--org edgexfoundry \
+--include 'edgex-global-pipelines' \
+--remove-version '>=1.0.20,<1.0.50'
 ```

--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ authors = [
 ]
 summary = 'A Python script that removes old pre-release tags from repos in a GitHub org'
 url = 'https://github.com/edgexfoundry/cd-management/tree/prune-github-tags'
-version = '0.0.1'
+version = '0.0.2'
 default_task = [
     'clean',
     'analyze',

--- a/src/unittest/python/test_api.py
+++ b/src/unittest/python/test_api.py
@@ -416,6 +416,26 @@ class TestApi(unittest.TestCase):
         }
         self.assertEqual(result, expected_result)
 
+    def test__generate_version_report_Should_ReturnExpected_When_Called(self, *patches):
+        tags = [
+            ('v1.2.4', 'sha3'),
+            ('v1.2.3', 'sha2'),
+            ('v1.2.2', 'sha1')
+        ]
+        result = GitHubAPI.generate_version_report(repo='repo1', version_tags=tags, latest_version=Version('1.2.4'), latest_version_sha='sha0')
+        expected_result = {
+            'repo1': {
+                'latest_version': ('1.2.4', 'sha0'),
+                'version_tags': [
+                    ('v1.2.4', 'sha3'),
+                    ('v1.2.3', 'sha2'),
+                    ('v1.2.2', 'sha1')
+                ],
+                'version_tags_count': 3
+            }
+        }
+        self.assertEqual(result, expected_result)
+
     @patch('prunetags.GitHubAPI.ratelimit_request')
     @patch('prunetags.GitHubAPI.get_prerelease_tags')
     def test__remove_prerelease_tags_Should_Return_When_NoTags(self, get_prerelease_tags_patch, ratelimit_request_patch, *patches):
@@ -507,6 +527,56 @@ class TestApi(unittest.TestCase):
         ]
         self.assertEqual(result, expected_result)
 
+    def test__filter_version_tags_Should_Return_Expected_When_Called(
+        self,
+        *patches
+    ):
+        tags = [
+            {'name': 'v1.2.4', 'commit': {'sha': 'sha1'}},
+            {'name': 'v1.2.3-dev.1', 'commit': {'sha': 'sha2'}},
+            {'name': 'v1.2.2', 'commit': {'sha': 'sha3'}},
+            {'name': 'v1.2.1', 'commit': {'sha': 'sha4'}},
+            {'name': 'v1.2.0-dev.1', 'commit': {'sha': 'sha5'}},
+            {'name': 'v1.1.9', 'commit': {'sha': 'sha6'}},
+            {'name': 'v1.1.4-dev.1', 'commit': {'sha': 'sha7'}}
+        ]
+        result = GitHubAPI.filter_version_tags(
+            tags=tags,
+            exclude=None,
+            expression='<=1.2.1')
+        expected_result = [
+            ('v1.2.1', 'sha4'),
+            ('v1.2.0-dev.1', 'sha5'),
+            ('v1.1.9', 'sha6'),
+            ('v1.1.4-dev.1', 'sha7')
+        ]
+        self.assertEqual(result, expected_result)
+
+    def test__filter_version_tags_Should_Return_Expected_When_Called_With_Range(
+        self, *patches
+    ):
+        tags = [
+            {'name': 'v1.2.4', 'commit': {'sha': 'sha1'}},
+            {'name': 'v1.2.3-dev.1', 'commit': {'sha': 'sha2'}},
+            {'name': 'v1.2.2', 'commit': {'sha': 'sha3'}},
+            {'name': 'v1.2.1', 'commit': {'sha': 'sha4'}},
+            {'name': 'v1.2.0-dev.1', 'commit': {'sha': 'sha5'}},
+            {'name': 'v1.1.9', 'commit': {'sha': 'sha6'}},
+            {'name': 'v1.1.4-dev.1', 'commit': {'sha': 'sha7'}}
+        ]
+        result = GitHubAPI.filter_version_tags(
+            tags=tags,
+            exclude=Version('1.2.3-dev.2'),
+            expression='<1.2.4,>1.1.4')
+        expected_result = [
+            ('v1.2.3-dev.1', 'sha2'),
+            ('v1.2.2', 'sha3'),
+            ('v1.2.1', 'sha4'),
+            ('v1.2.0-dev.1', 'sha5'),
+            ('v1.1.9', 'sha6')
+        ]
+        self.assertEqual(result, expected_result)
+
     @patch('prunetags.api.validate_version', return_value=False)
     def test__get_version_Should_ReturnExpected_When_Called(self, *patches):
         result = GitHubAPI.get_version(name='enjambre')
@@ -539,3 +609,93 @@ class TestApi(unittest.TestCase):
         function_mock.assert_called_once_with('one', 2, True, k1='v1', k2='v2', raw_response=True)
         self.assertEqual(result, function_mock.return_value)
         response_mock.raise_for_status.assert_called_once_with()
+
+    @patch('prunetags.GitHubAPI.ratelimit_request')
+    @patch('prunetags.GitHubAPI.get_version_tags')
+    def test__remove_version_tags_Should_Return_When_NoTags(self, get_version_tags_patch, ratelimit_request_patch, *patches):
+        get_version_tags_patch.return_value = None
+        client = GitHubAPI('api.github.com', bearer_token='bearer-token')
+        client.remove_version_tags(repo='org1/repo1', branch='master', noop=False)
+        ratelimit_request_patch.assert_not_called()
+
+    @patch('prunetags.api.sleep')
+    @patch('prunetags.GitHubAPI.ratelimit_request')
+    @patch('prunetags.GitHubAPI.get_version_tags')
+    def test__remove_version_tags_Should_CallExpected_When_Called(self, get_version_tags_patch, ratelimit_request_patch, *patches):
+        get_version_tags_patch.return_value = (
+            [('tag1', 'sha1'), ('tag2', 'sha2')], '-latest-version-', '-latest-version-sha-'
+        )
+        client = GitHubAPI('api.github.com', bearer_token='bearer-token')
+        client.remove_version_tags(repo='org1/repo1', branch='master', noop=True)
+        ratelimit_request_patch.assert_called_with(client.delete, '/repos/org1/repo1/git/refs/tags/tag2', noop=True)
+
+    @patch('prunetags.api.sleep')
+    @patch('prunetags.api.logger')
+    @patch('prunetags.GitHubAPI.ratelimit_request')
+    @patch('prunetags.GitHubAPI.get_version_tags')
+    def test__remove_version_tags_Should_LogErrorAndContinue_When_Exception(self, get_version_tags_patch, ratelimit_request_patch, logger_patch, *patches):
+        get_version_tags_patch.return_value = (
+            [('tag1', 'sha1'), ('tag2', 'sha2')], '-latest-version-', '-latest-version-sha-'
+        )
+        ratelimit_request_patch.side_effect = [
+            Exception('request error'),
+            None
+        ]
+        client = GitHubAPI('api.github.com', bearer_token='bearer-token')
+        client.remove_version_tags(repo='org1/repo1', branch='master', noop=True)
+        ratelimit_request_patch.assert_called_with(client.delete, '/repos/org1/repo1/git/refs/tags/tag2', noop=True)
+        logger_patch.error.assert_called_with('error occurred removing tag tag1 from repo org1/repo1: request error')
+
+    @patch('prunetags.GitHubAPI.get_latest_version')
+    @patch('prunetags.GitHubAPI.read_all')
+    def test__get_version_tags_Should_Return_When_NoTags(self, read_all_patch, get_latest_version_patch, *patches):
+        read_all_patch.return_value = []
+        client = GitHubAPI('api.github.com', bearer_token='bearer-token')
+        client.get_version_tags(repo='org1/repo1', branch='master')
+        get_latest_version_patch.assert_not_called()
+
+    @patch('prunetags.GitHubAPI.read_all')
+    @patch('prunetags.GitHubAPI.filter_prerelease_tags')
+    @patch('prunetags.GitHubAPI.get_latest_version')
+    def test__get_version_tags_Should_Return_When_NoLatestTagVersion(self, get_latest_version_patch, filter_version_tags_patch, *patches):
+        get_latest_version_patch.return_value = (None, None)
+        client = GitHubAPI('api.github.com', bearer_token='bearer-token')
+        client.get_version_tags(repo='org1/repo1', branch='master')
+        filter_version_tags_patch.assert_not_called()
+
+    @patch('prunetags.GitHubAPI.read_all')
+    @patch('prunetags.GitHubAPI.filter_version_tags')
+    @patch('prunetags.GitHubAPI.get_latest_version')
+    def test__get_version_tags_Should_CallAndReturnExpected_When_Called(self, get_latest_version_patch, filter_version_tags_patch, *patches):
+        get_latest_version_patch.return_value = Version('1.2.3-dev.1'), 'sha0'
+        client = GitHubAPI('api.github.com', bearer_token='bearer-token')
+        result = client.get_version_tags(repo='org1/repo1', branch='master')
+        expected_result = (filter_version_tags_patch.return_value, Version('1.2.3-dev.1'), 'sha0')
+        self.assertEqual(result, expected_result)
+
+    @patch('prunetags.GitHubAPI.generate_version_report')
+    @patch('prunetags.GitHubAPI.get_version_tags')
+    def test__get_version_tags_report_Should_ReturnExpected_When_Called(self, get_version_tags_patch, generate_version_report, *patches):
+        get_version_tags_patch.side_effect = [
+            ('-tags-', '-latest-version-', '-latest-version-sha-'),
+            None,
+            ('-tags-', '-latest-version-', '-latest-version-sha-'),
+        ]
+        generate_version_report.side_effect = [
+            {'repo1': {}},
+            {'repo3': {}}
+        ]
+        client = GitHubAPI('api.github.com', bearer_token='bearer-token')
+        repos = [
+            'repo1',
+            'repo2',
+            'repo3'
+        ]
+        expression = '<=1.1.1'
+        result = client.get_version_tags_report(repos=repos, expression=expression)
+        expected_result = {
+            'repo1': {},
+            'repo2': {},
+            'repo3': {}
+        }
+        self.assertEqual(result, expected_result)


### PR DESCRIPTION
EdgeX DevOps: Implement ability to prune semver version tags from edgexfoundry repos with a given range.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
#62 

## Sandbox Testing
Run with NOOP / DryRun on Sandbox server against `edgex-global-pipelines` with `--version <1.0.87`
[Sandbox Functional Test Build Link](https://jenkins.edgexfoundry.org/sandbox/view/All/job/Functional-Testing/job/prune-github-version-tags/3/console)

## Are there any specific instructions or things that should be known prior to reviewing?
Piggybacks on existing GitHub API and functionality from prune-github-tags python module.

## Other information
```
[INFO]  Overall coverage is 100%
[INFO]  Overall coverage branch coverage is 87%
[INFO]  Overall coverage partial branch coverage is 87%
[INFO]  Average complexity: A (3.25531914893617)
```

Closes: #62 