### PR TITLE
fix(jenkinsfile): Remove --report option from default execution.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sh "prune-github-tags --org edgexfoundry --procs 10 --report ${params.Execute} ${params.Version} ${params['Include Repositories']}"
+                        sh "prune-github-tags --org edgexfoundry --procs 10 ${params.Execute} ${params.Version} ${params['Include Repositories']}"
                     }
                 }
             }


### PR DESCRIPTION
--Report option only executes a report and will not execute command, regardless if --execute is specified. 

It would be nice if --report would be in addition to --execute but instead of changing the scope of the tool it's more productive to default to the --execute option when running on Jenkins by removing the --report option from the Jenkinsfile

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:

## Sandbox Testing


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information


Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>