### PR TITLE
Add create-github-release capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.6-alpine AS build-image
+
+ENV PYTHONDONTWRITEBYTECODE 1
+
+WORKDIR /create-github-release
+
+COPY . /create-github-release/
+
+RUN apk update
+RUN apk add git libmagic
+RUN pip install --upgrade pip
+RUN pip install pybuilder==0.11.17
+RUN pyb install_dependencies
+RUN pyb
+RUN pyb publish
+
+FROM python:3.6-alpine
+
+ENV PYTHONDONTWRITEBYTECODE 1
+
+WORKDIR /opt/create-github-release
+
+COPY --from=build-image /create-github-release/target/dist/ghrelease-*/dist/ghrelease-*.tar.gz /opt/create-github-release
+
+# the following lines are necessary because github3api isn't yet published to PyPi
+# once it is published then the following lines will be removed
+RUN apk add --update --no-cache git gcc libc-dev libffi-dev openssl-dev wget libmagic
+RUN pip install git+https://github.com/soda480/github3api.git@master#egg=github3api
+
+RUN pip install ghrelease-*.tar.gz
+
+CMD echo 'DONE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+edgeXBuildDocker(
+    project: 'create-github-release',
+    arch: ['amd64'],
+    mavenSettings: 'ci-build-images-settings',
+    dockerImageName: 'github-release',
+    dockerNamespace: 'edgex-devops',
+    dockerNexusRepo: 'snapshots',
+    dockerTags: ['0.0.1'],
+    releaseBranchOverride: 'create-github-release'
+)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# cd-management
+# create-github-release #
+A Python script to facilitate creation of GitHub releases with assets.
+
+### `create-github-release` ###
+
+```bash
+usage: create-github-release [-h] --repo REPO --tag TAG --assets ASSETS
+                             [--release RELEASE] [--debug]
+
+A Python script to facilitate creation of GitHub releases with assets
+
+optional arguments:
+  -h, --help         show this help message and exit
+  --repo REPO        GitHub repo where release is to be created
+  --tag TAG          The name of the existing tag to associate with the
+                     release
+  --assets ASSETS    The name of the directory containing the assets to upload
+                     to the release
+  --release RELEASE  The name to give the release - if not provided will use
+                     name of tag
+  --debug            display debug messages to stdout
+```
+
+#### Environment Variables
+
+* `GH_TOKEN_PSW`  (Required) - The GitHub personal access token used to authenticate GitHub Commands
+* `GH_BASE_URL`   (Optional) - GitHub API URL. Can be changed to point to a different GitHub API endpoint
+
+#### Examples
+
+create a release associated with the `v1.2.3` tag in the `soda480/test123` repo and upload all files in the `bin/` folder as assets for the release:
+```bash
+create-github-release --repo 'soda480/test123' --tag 'v1.2.3' --assets 'bin/'
+```
+
+### Development ###
+
+Ensure the latest version of Docker is installed on your development server and clone the repository.
+
+Build the Docker image:
+```sh
+docker image build \
+--target build-image \
+--build-arg http_proxy \
+--build-arg https_proxy \
+-t \
+create-github-release:latest .
+```
+
+Run the Docker container:
+```sh
+docker container run \
+--rm \
+-it \
+-e http_proxy \
+-e https_proxy \
+-v $PWD:/create-github-release \
+create-github-release:latest \
+/bin/sh
+```
+
+Execute the build:
+```sh
+pyb -X
+```
+
+NOTE: commands above assume working behind a proxy, if not then the proxy arguments to both the docker build and run commands can be removed.

--- a/build.py
+++ b/build.py
@@ -1,0 +1,80 @@
+
+# Copyright (c) 2020 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pybuilder.core import use_plugin
+from pybuilder.core import init
+from pybuilder.core import Author
+from pybuilder.core import task
+from pybuilder.pluginhelper.external_command import ExternalCommandBuilder
+from pybuilder.utils import read_file
+import json
+
+use_plugin('python.core')
+use_plugin('python.unittest')
+use_plugin('python.install_dependencies')
+use_plugin('python.flake8')
+use_plugin('python.coverage')
+use_plugin('python.distutils')
+use_plugin('filter_resources')
+
+name = 'ghrelease'
+authors = [
+    Author('Emilio Reyes', 'emilio.reyes@intel.com')
+]
+summary = 'A Python script to facilitate creation of GitHub releases with assets'
+url = 'https://github.com/edgexfoundry/cd-management/tree/create-github-release'
+version = '0.0.1'
+default_task = [
+    'clean',
+    'analyze',
+    'cyclomatic_complexity',
+    'package'
+]
+
+
+@init
+def set_properties(project):
+    project.set_property('unittest_module_glob', 'test_*.py')
+    project.set_property('coverage_break_build', False)
+    project.set_property('flake8_max_line_length', 120)
+    project.set_property('flake8_verbose_output', True)
+    project.set_property('flake8_break_build', True)
+    project.set_property('flake8_include_scripts', True)
+    project.set_property('flake8_include_test_sources', True)
+    project.set_property('flake8_ignore', 'E501, W503, F401, E722, W605')
+    project.build_depends_on_requirements('requirements-build.txt')
+    project.depends_on_requirements('requirements.txt')
+    project.set_property('distutils_console_scripts',
+        ['create-github-release = ghrelease.cli:main'])
+
+
+@task('cyclomatic_complexity', description='calculates and publishes cyclomatic complexity')
+def cyclomatic_complexity(project, logger):
+    try:
+        command = ExternalCommandBuilder('radon', project)
+        command.use_argument('cc')
+        command.use_argument('-a')
+        result = command.run_on_production_source_files(logger)
+        if len(result.error_report_lines) > 0:
+            logger.error('Errors while running radon, see {0}'.format(result.error_report_file))
+        for line in result.report_lines[:-1]:
+            logger.debug(line.strip())
+        if not result.report_lines:
+            return
+        average_complexity_line = result.report_lines[-1].strip()
+        logger.info(average_complexity_line)
+
+    except Exception as exception:
+        print('ERROR: unable to execute cyclomatic complexity due to: {}'.format(str(exception)))

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,7 @@
+coverage
+flake8
+pypandoc
+unittest-xml-reporting
+mccabe
+mock
+radon

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-magic
+uritemplate
+-e git+https://github.com/soda480/github3api.git@master#egg=github3api

--- a/src/main/python/ghrelease/__init__.py
+++ b/src/main/python/ghrelease/__init__.py
@@ -1,0 +1,15 @@
+
+# Copyright (c) 2020 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .api import API

--- a/src/main/python/ghrelease/api.py
+++ b/src/main/python/ghrelease/api.py
@@ -1,0 +1,152 @@
+
+# Copyright (c) 2020 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from magic import Magic
+from github3api import GitHubAPI
+from requests.exceptions import SSLError
+from requests.exceptions import ProxyError
+from requests.exceptions import ConnectionError
+from uritemplate import URITemplate, expand
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class ReleaseAlreadyExists(Exception):
+    pass
+
+
+class API(GitHubAPI):
+
+    def __init__(self, **kwargs):
+        logger.debug('executing API constructor')
+
+        if not kwargs.get('bearer_token'):
+            raise ValueError('bearer_token must be provided')
+
+        retries = [{
+            'retry_on_exception': API.is_connection_error,
+            'wait_random_min': 10000,
+            'wait_random_max': 20000,
+            'stop_max_attempt_number': 6
+        }]
+
+        super(API, self).__init__(retries=retries, **kwargs)
+
+        self.items_to_redact.append('data')
+
+    def create_release_upload_assets(self, repo, tag_name, directory, release_name=None, description=None):
+        """ create release on repo and upload assets from directory
+        """
+        release = self.create_release(repo, tag_name, release_name=release_name, description=description)
+        self.upload_assets(directory, release)
+
+    def validate_release(self, repo, tag_name, release_name):
+        """ validate release with specified meta-data does not exist
+        """
+        releases = self.get(f'/repos/{repo}/releases', _get='all', _attributes=['id', 'name', 'tag_name'])
+        for release in releases:
+            if tag_name == release['tag_name']:
+                raise ReleaseAlreadyExists(f"A release with tag {release['tag_name']} already exists")
+            if release_name == release['name']:
+                raise ReleaseAlreadyExists(f"A release with name {release['name']} already exists")
+
+    def create_release(self, repo, tag_name, release_name=None, description=None):
+        """ create release for repo with specified meta-data
+        """
+        if not release_name:
+            release_name = tag_name
+        if not description:
+            description = tag_name
+
+        self.validate_release(repo, tag_name, release_name)
+
+        logger.info(f'creating release {release_name} with tag {tag_name} description {description} on repo {repo}')
+        response = self.post(
+            f'/repos/{repo}/releases',
+            json={
+                'tag_name': tag_name,
+                'name': release_name,
+                'body': description
+            })
+
+        response['repo'] = repo
+        return response
+
+    def upload_assets(self, directory, release):
+        """ upload all assets in directory to release
+        """
+        assets = API.get_assets(directory)
+        for asset in assets:
+            self.upload_asset(asset, release)
+
+    def upload_asset(self, asset, release):
+        """ upload asset to release
+        """
+        logger.info(f"uploading asset {asset['name']} to repo {release['repo']} release {release['name']}")
+        self.post(
+            API.get_upload_url(release['upload_url'], asset['name'], asset['label']),
+            headers={'Content-Type': asset['content-type']},
+            data=asset['content'])
+
+    @staticmethod
+    def get_assets(directory):
+        """ return assets discovered in directory
+        """
+        assets = []
+        for _, _, files in os.walk(directory):
+            for file in files:
+                assets.append({
+                    'name': file,
+                    'label': None,
+                    'content': API.get_content(os.path.join(directory, file)),
+                    'content-type': API.get_content_type(file)
+                })
+        return assets
+
+    @staticmethod
+    def get_upload_url(upload_url_template, name, label):
+        """ return upload url from upload uri template
+        """
+        uri_template = URITemplate(upload_url_template)
+        return uri_template.expand(name=name, label=label)
+
+    @staticmethod
+    def get_content(file_name):
+        """ read and return content of file
+        """
+        with open(file_name, 'rb') as in_file:
+            content = in_file.read()
+        return content
+
+    @staticmethod
+    def get_content_type(file_name):
+        """ return associated content type for file
+        """
+        try:
+            return Magic(mime=True).from_file(file_name)
+        except:
+            return 'text/plain'
+
+    @staticmethod
+    def is_connection_error(exception):
+        """ return True if exception is SSLError, ProxyError or ConnectError, False otherwise
+        """
+        logger.debug(f'checking exception for retry candidacy: {type(exception).__name__}')
+        if isinstance(exception, (SSLError, ProxyError, ConnectionError)):
+            logger.info('connectivity error - retrying request in a few seconds')
+            return True
+        return False

--- a/src/main/python/ghrelease/cli.py
+++ b/src/main/python/ghrelease/cli.py
@@ -1,0 +1,129 @@
+
+# Copyright (c) 2020 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import logging
+from argparse import ArgumentParser
+
+from ghrelease import API
+
+logger = logging.getLogger(__name__)
+
+
+class MissingArgumentError(Exception):
+    """ argument error
+    """
+    pass
+
+
+def get_parser():
+    """ setup parser and return parsed command line arguments
+    """
+    parser = ArgumentParser(
+        description='A Python script to facilitate creation of GitHub releases with assets')
+    parser.add_argument(
+        '--repo',
+        dest='repo',
+        type=str,
+        required=True,
+        help='GitHub repo where release is to be created')
+    parser.add_argument(
+        '--tag',
+        dest='tag',
+        type=str,
+        required=True,
+        help='The name of the existing tag to associate with the release')
+    parser.add_argument(
+        '--assets',
+        dest='assets',
+        type=str,
+        required=True,
+        help='The name of the directory containing the assets to upload to the release')
+    parser.add_argument(
+        '--release',
+        dest='release',
+        type=str,
+        required=False,
+        help='The name to give the release - if not provided will use name of tag')
+    parser.add_argument(
+        '--debug',
+        dest='debug',
+        action='store_true',
+        help='display debug messages to stdout')
+    return parser
+
+
+def validate(args):
+    """ validate args
+    """
+    if not os.access(args.assets, os.R_OK):
+        raise ValueError(f'the directory {args.assets} is not accessible')
+
+
+def get_client():
+    """ return instance of API
+    """
+    return API(
+        hostname=os.getenv('GH_BASE_URL', 'api.github.com'),
+        bearer_token=os.getenv('GH_TOKEN_PSW'))
+
+
+def set_logging(args):
+    """ configure logging
+    """
+    rootLogger = logging.getLogger()
+    # must be set to this level so handlers can filter from this level
+    rootLogger.setLevel(logging.DEBUG)
+
+    logfile = '{}/create-github-release.log'.format(os.getenv('PWD'))
+    file_handler = logging.FileHandler(logfile)
+    file_formatter = logging.Formatter("%(asctime)s %(processName)s %(name)s [%(funcName)s] %(levelname)s %(message)s")
+    file_handler.setFormatter(file_formatter)
+    file_handler.setLevel(logging.DEBUG)
+    rootLogger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    formatter = '%(asctime)s %(name)s [%(funcName)s] %(levelname)s %(message)s'
+    stream_formatter = logging.Formatter(formatter)
+    stream_handler.setFormatter(stream_formatter)
+    stream_handler.setLevel(logging.DEBUG if args.debug else logging.INFO)
+    rootLogger.addHandler(stream_handler)
+
+
+def main():
+    """ main function
+    """
+    parser = get_parser()
+    try:
+        args = parser.parse_args()
+        validate(args)
+        set_logging(args)
+        client = get_client()
+        client.create_release_upload_assets(
+            args.repo, args.tag, args.assets, release_name=args.release)
+
+    except MissingArgumentError as exception:
+        parser.print_usage()
+        logger.error("ERROR: {}".format(str(exception)))
+
+    except Exception as exception:
+        logger.error("ERROR: {}".format(str(exception)))
+        sys.exit(-1)
+
+
+if __name__ == '__main__':  # pragma: no cover
+
+    main()

--- a/src/unittest/python/test_api.py
+++ b/src/unittest/python/test_api.py
@@ -1,0 +1,174 @@
+
+# Copyright (c) 2020 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from mock import patch
+from mock import mock_open
+from mock import call
+from mock import Mock
+
+from ghrelease import API
+from ghrelease.api import ReleaseAlreadyExists
+
+from requests.exceptions import SSLError
+from requests.exceptions import ProxyError
+from requests.exceptions import ConnectionError
+
+import sys
+import logging
+logger = logging.getLogger(__name__)
+
+consoleHandler = logging.StreamHandler(sys.stdout)
+logFormatter = logging.Formatter("%(asctime)s %(threadName)s %(name)s [%(funcName)s] %(levelname)s %(message)s")
+consoleHandler.setFormatter(logFormatter)
+rootLogger = logging.getLogger()
+rootLogger.addHandler(consoleHandler)
+rootLogger.setLevel(logging.DEBUG)
+
+
+class TestApi(unittest.TestCase):
+
+    def setUp(self):
+
+        pass
+
+    def tearDown(self):
+
+        pass
+
+    def test__init_Should_RaiseValueError_When_NoBearerToken(self, *patches):
+        with self.assertRaises(ValueError):
+            API()
+
+    @patch('ghrelease.api.API.upload_assets')
+    @patch('ghrelease.api.API.create_release')
+    def test__create_release_upload_assets_Should_CallExpected_When_Called(self, create_release_patch, upload_assets_patch, *patches):
+        client = API(bearer_token='token')
+        client.create_release_upload_assets('org1/repo1', 'v1.0.0', 'assets/')
+        upload_assets_patch.assert_called_once_with('assets/', create_release_patch.return_value)
+
+    @patch('ghrelease.api.API.get')
+    def test__validate_release_Should_RaiseReleaseAlreadyExists_When_TagExists(self, get_patch, *patches):
+        get_patch.return_value = [
+            {'tag_name': 'v1.0.0'}
+        ]
+        client = API(bearer_token='token')
+        with self.assertRaises(ReleaseAlreadyExists):
+            client.validate_release('org1/repo1', 'v1.0.0', 'v1.0.0')
+
+    @patch('ghrelease.api.API.get')
+    def test__validate_release_Should_RaiseReleaseAlreadyExists_When_ReleaseExists(self, get_patch, *patches):
+        get_patch.return_value = [
+            {'tag_name': 'v1.0.1', 'name': 'v1.0.1'}
+        ]
+        client = API(bearer_token='token')
+        with self.assertRaises(ReleaseAlreadyExists):
+            client.validate_release('org1/repo1', 'v1.0.0', 'v1.0.1')
+
+    @patch('ghrelease.api.API.validate_release')
+    @patch('ghrelease.api.API.post')
+    def test__create_release_Should_CallExpected_When_Called(self, post_patch, *patches):
+        post_patch.return_value = {}
+        client = API(bearer_token='token')
+        result = client.create_release('org1/repo1', 'v1.0.0')
+        post_patch.assert_called_once_with(
+            '/repos/org1/repo1/releases',
+            json={
+                'tag_name': 'v1.0.0',
+                'name': 'v1.0.0',
+                'body': 'v1.0.0'
+            })
+        self.assertEqual(result['repo'], 'org1/repo1')
+
+    @patch('ghrelease.api.API.upload_asset')
+    @patch('ghrelease.api.API.get_assets')
+    def test__upload_assets_Should_CallExpected_When_Called(self, get_assets_patch, upload_asset_patch, *patches):
+        get_assets_patch.return_value = ['asset1', 'asset2']
+        client = API(bearer_token='token')
+        client.upload_assets('assets/', 'v1.0.0')
+        upload_asset_call1 = call('asset1', 'v1.0.0')
+        upload_asset_call2 = call('asset2', 'v1.0.0')
+        self.assertTrue(upload_asset_call1 in upload_asset_patch.mock_calls)
+        self.assertTrue(upload_asset_call2 in upload_asset_patch.mock_calls)
+
+    @patch('ghrelease.api.API.get_upload_url')
+    @patch('ghrelease.api.API.post')
+    def test__upload_asset_Should_CallExpected_When_Called(self, post_patch, get_upload_url_patch, *patches):
+        client = API(bearer_token='token')
+        asset_mock = {
+            'name': 'file.txt',
+            'label': None,
+            'content-type': 'text/plain',
+            'content': 'content'
+        }
+        client.upload_asset(asset_mock, {'repo': 'org1/repo1', 'name': 'v1.0.0', 'upload_url': 'upload_url'})
+        post_patch.assert_called_once_with(
+            get_upload_url_patch.return_value,
+            headers={'Content-Type': asset_mock['content-type']},
+            data=asset_mock['content'])
+
+    @patch('ghrelease.api.API.get_content', return_value='content')
+    @patch('ghrelease.api.API.get_content_type', return_value='content-type')
+    @patch('ghrelease.api.os.walk')
+    def test__get_assets_Should_CallAndReturnExpected_When_Called(self, walk_patch, *patches):
+        walk_patch.return_value = [
+            ('', '', ['file1', 'file2'])
+        ]
+        result = API.get_assets('assets/')
+        expected_result = [
+            {'name': 'file1', 'label': None, 'content': 'content', 'content-type': 'content-type'},
+            {'name': 'file2', 'label': None, 'content': 'content', 'content-type': 'content-type'}
+        ]
+        self.assertEqual(result, expected_result)
+
+    @patch('ghrelease.api.URITemplate')
+    def test__get_upload_url_Should_ReturnExpected_When_Called(self, uritemplate_patch, *patches):
+        uritemplate_mock = Mock()
+        uritemplate_patch.return_value = uritemplate_mock
+        result = API.get_upload_url('template', 'name', 'label')
+        self.assertEqual(result, uritemplate_mock.expand.return_value)
+
+    @patch("builtins.open", new_callable=mock_open, read_data='data')
+    def test__get_content_Should_ReturnExpected_When_Called(self, *patches):
+        result = API.get_content('file')
+        self.assertEqual(result, 'data')
+
+    @patch('ghrelease.api.Magic')
+    def test__get_content_type_Should_ReturnExpected_When_Exception(self, magic_patch, *patches):
+        magic_patch.side_effect = Exception('some exception')
+        result = API.get_content_type('file')
+        expected_result = 'text/plain'
+        self.assertEqual(result, expected_result)
+
+    @patch('ghrelease.api.Magic')
+    def test__get_content_type_Should_ReturnExpected_When_Called(self, magic_patch, *patches):
+        result = API.get_content_type('file')
+        self.assertEqual(result, magic_patch.return_value.from_file.return_value)
+
+    def test__is_connection_error_Should_Return_False_When_NoMatch(self, *patches):
+
+        self.assertFalse(API.is_connection_error(Exception('test')))
+
+    def test__is_connection_error_Should_Return_True_When_SSLError(self, *patches):
+
+        self.assertTrue(API.is_connection_error(SSLError('test')))
+
+    def test__is_connection_error_Should_Return_True_When_ProxyError(self, *patches):
+
+        self.assertTrue(API.is_connection_error(ProxyError('test')))
+
+    def test__is_connection_error_Should_Return_True_When_ConnectionError(self, *patches):
+
+        self.assertTrue(API.is_connection_error(ConnectionError('test')))

--- a/src/unittest/python/test_cli.py
+++ b/src/unittest/python/test_cli.py
@@ -1,0 +1,103 @@
+
+# Copyright (c) 2020 Intel Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from mock import patch
+from mock import mock_open
+from mock import call
+from mock import Mock
+
+from ghrelease.cli import MissingArgumentError
+from ghrelease.cli import get_parser
+from ghrelease.cli import validate
+from ghrelease.cli import get_client
+from ghrelease.cli import set_logging
+from ghrelease.cli import main
+
+from argparse import Namespace
+from datetime import datetime
+
+
+class TestCli(unittest.TestCase):
+
+    def setUp(self):
+
+        pass
+
+    def tearDown(self):
+
+        pass
+
+    @patch('ghrelease.cli.ArgumentParser')
+    def test__get_parser_Should_ReturnExpected_When_Called(self, *patches):
+        # not much to unit test here
+        get_parser()
+
+    @patch('ghrelease.cli.os.access', return_value=False)
+    def test__validate_Should_RaiseValueError_When_AssetsAreNotAccessible(self, *patches):
+        args = Namespace(repo='org1/repo1', tag='v1.0.0', assets='assets/')
+        with self.assertRaises(ValueError):
+            validate(args)
+
+    @patch('ghrelease.cli.os.getenv')
+    @patch('ghrelease.cli.API')
+    def test__get_client_Should_CallExpected_When_Called(self, api_patch, getenv_patch, *patches):
+        getenv_patch.side_effect = ['api.github.com', 'token']
+        get_client()
+        api_patch.assert_called_once_with(hostname='api.github.com', bearer_token='token')
+
+    @patch('ghrelease.cli.os.getenv')
+    @patch('ghrelease.cli.logging')
+    def test__set_logging_Should_CallExpected_When_Called(self, logging_patch, *patches):
+        root_logger_mock = Mock()
+        logging_patch.getLogger.return_value = root_logger_mock
+        args_mock = Namespace(repo='org1/repo1', tag='v1.0.0', assets='assets/', debug=True)
+        # not much to test here
+        set_logging(args_mock)
+
+    @patch('ghrelease.cli.logger')
+    @patch('ghrelease.cli.get_parser')
+    def test__main_Should_PrintUsage_When_MissingArgumentError(self, get_parser_patch, logger_patch, *patches):
+        parser_mock = Mock()
+        parser_mock.parse_args.side_effect = [MissingArgumentError('error')]
+        get_parser_patch.return_value = parser_mock
+        main()
+        parser_mock.print_usage.assert_called_once_with()
+        logger_patch.error.assert_called()
+
+    @patch('ghrelease.cli.sys')
+    @patch('ghrelease.cli.logger')
+    @patch('ghrelease.cli.get_parser')
+    def test__main_Should_Exit_When_Exception(self, get_parser_patch, logger_patch, sys_patch, *patches):
+        parser_mock = Mock()
+        parser_mock.parse_args.side_effect = [Exception('error')]
+        get_parser_patch.return_value = parser_mock
+        main()
+        logger_patch.error.assert_called()
+        sys_patch.exit.assert_called_once_with(-1)
+
+    @patch('ghrelease.cli.set_logging')
+    @patch('ghrelease.cli.validate')
+    @patch('ghrelease.cli.get_parser')
+    @patch('ghrelease.cli.get_client')
+    def test__main_Should_CallExpected_When_Called(self, get_client_patch, get_parser_patch, *patches):
+        parser_mock = Mock()
+        parser_mock.parse_args.return_value = Namespace(repo='org1/repo1', tag='v1.0.0', assets='assets/', release=None)
+        get_parser_patch.return_value = parser_mock
+        client_mock = Mock()
+        get_client_patch.return_value = client_mock
+        main()
+        client_mock.create_release_upload_assets.assert_called_once_with(
+            'org1/repo1', 'v1.0.0', 'assets/', release_name=None)


### PR DESCRIPTION
A Python script to facilitate creation of GitHub releases with assets.

This is the foundational capability required to provide our release automation the ability to create GitHub releases and upload assets/artifacts to the release..

I am leveraging the `edgeXBuildDocker` Jenkins shared library to build and publish the associated docker image to Nexus directly. Doing so, eliminates the need of having to create an additional branch under `ci-build-images`  to publish the docker image. 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/edgexfoundry/ci-management/blob/master/.github/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Added labels

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Issue Number:
https://github.com/edgexfoundry/edgex-global-pipelines/issues/242

## Sandbox Testing
Tested Jenkinsfile on Sandbox: https://jenkins.edgexfoundry.org/sandbox/view/All/job/Functional-Testing/job/cd-management-create-github-release/

## Are there any new imports or modules? If so, what are they used for and why?

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
Unit Test Coverage:
```
[INFO]  Overall coverage is 100%
```
Cyclomatic Complexity:
```
[INFO]  Average complexity: A (1.894736842105263)
```