### PR TITLE
Fix intermittent ratelimit error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build-status](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/job/git-label-sync/badge/icon)](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/job/git-label-sync)
+
 # cd-management/git-label-sync
 
 ## Summary
@@ -94,3 +96,38 @@ Start `2` concurrent processes with screen and only include sources that have be
 ```Script
 githubsync --procs 2 --modified-since 1d --noop --screen
 ```
+
+### Development
+Clone the repository:
+```
+cd
+git clone https://github.com/edgexfoundry/cd-management.git sync-github-labels
+cd sync-github-labels
+```
+
+Build the Docker image:
+```
+docker image build \
+--build-arg http_proxy \
+--build-arg https_proxy \
+-t \
+githubsync:latest .
+```
+
+Run the Docker container:
+```
+docker container run \
+--rm \
+-it \
+-e http_proxy \
+-e https_proxy \
+-v $PWD:/githubsync \
+githubsync:latest \
+/bin/sh
+```
+
+Execute the build:
+```
+pyb -X
+```
+NOTE: commands above assume working behind a proxy, if not then the proxy arguments to both the docker build and run commands can be removed.

--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ authors = [
 ]
 summary = 'A Python script to synchronize labels for repositories in a GitHub organization'
 url = 'https://github.com/edgexfoundry/cd-management/tree/git-label-sync'
-version = '0.0.3'
+version = '0.0.4'
 default_task = [
     'clean',
     'analyze',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ratelimit
 retrying
 pytz
 rest3client


### PR DESCRIPTION
- Fix intermittent ratelimit error - error was due to the fact that I forgot to decorate the `modified_since` method with a retry decorator.
- I cleaned up the logic so that all ratelimit requests go through the ratelimit_request method.
- Added log file as artifact to build job
- Added more debug logging statements to facilitate future troubleshooting

Fixes: https://github.com/edgexfoundry/cd-management/issues/77

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>