### PR TITLE
run docker-bench-security checks against EdgeX stack

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,47 @@
+pipeline {
+    agent { label 'centos7-docker-8c-8g' }
+
+    stages {
+        stage('Prep') {
+            steps {
+                script {
+                    sh "curl -v https://raw.githubusercontent.com/edgexfoundry/developer-scripts/master/releases/nightly-build/compose-files/docker-compose-nexus.yml > docker-compose.yml"
+                    docker
+                        .image('nexus3.edgexfoundry.org:10003/edgex-devops/edgex-compose:latest')
+                        .inside('-u 0:0 --entrypoint= --net host --security-opt label:disable -v /var/run/docker.sock:/var/run/docker.sock')
+                    {
+                        sh """
+                            docker ps -a
+                            docker-compose up -d
+                            sleep 60
+                            docker ps -a
+                        """
+                    }
+                }
+            }
+        }
+
+        stage('CIS Benchmark') {
+            steps {
+                script {
+                    def checks = ['check_4_1','check_5_3','check_5_4','check_5_5','check_5_6','check_5_7',
+                        'check_5_9','check_5_12','check_5_15','check_5_16','check_5_19','check_5_20',
+                        'check_5_21','check_5_24','check_5_25','check_5_29','check_5_30','check_5_31'
+                    ]
+                    sh """
+                        docker run --net host --pid host --cap-add audit_control \
+                        -e DOCKER_CONTENT_TRUST= -v /var/lib:/var/lib -v /var/run/docker.sock:/var/run/docker.sock \
+                        -v /usr/lib/systemd:/usr/lib/systemd -v /etc:/etc --label docker_bench_security \
+                        docker/docker-bench-security -c ${checks.join(',')}
+                    """
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            edgeXInfraPublish()
+        }
+    }
+}


### PR DESCRIPTION
* Executing docker-bench-security checks proposed in [ADR](https://github.com/edgexfoundry/edgex-docs/pull/220) on [EdgeX Foundry stack](https://github.com/edgexfoundry/developer-scripts/blob/master/releases/nightly-build/compose-files/docker-compose-nexus.yml).
* Publish all the logs to nexus for archival.
* [Build info](https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/Functional-Testing%2Fvenkat-edgex-cis-benchmark-v2/detail/venkat-edgex-cis-benchmark-v2/2/)