### PR TITLE
release (hanoi): Release Device and Application SDKs

### DIFF
--- a/release/app-functions-sdk-go.yaml
+++ b/release/app-functions-sdk-go.yaml
@@ -1,9 +1,8 @@
 ---
 name: 'app-functions-sdk-go'
-version: '1.2.0'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/app-functions-sdk-go.git'
 gitTag: true
 dockerImages: false
-snap: false

--- a/release/device-sdk-c.yaml
+++ b/release/device-sdk-c.yaml
@@ -1,9 +1,8 @@
 ---
 name: 'device-sdk-c'
-version: '1.2.2'
-releaseName: 'geneva'
-releaseStream: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
+releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-sdk-c.git'
 gitTag: true
 dockerImages: false
-snap: false

--- a/release/device-sdk-go.yaml
+++ b/release/device-sdk-go.yaml
@@ -1,9 +1,8 @@
 ---
 name: 'device-sdk-go'
-version: '1.2.3'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-sdk-go.git'
 gitTag: true
 dockerImages: false
-snap: false


### PR DESCRIPTION
@iain-anderson , @rsdmike , can you both look to ensure this SDK release looks good? For SDK's we just tag the repo.

CC: @jpwhitemn , @lenny-intel 

device-sdk-c (v1.3.0)
device-sdk-go (v1.3.0)
app-functions-sdk-go (v1.3.0)

Scheduled for release Nov 11th

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>