### PR TITLE
release(hanoi): Release Device Services

### DIFF
--- a/release/device-bacnet-c.yaml
+++ b/release/device-bacnet-c.yaml
@@ -1,7 +1,7 @@
 ---
 name: 'device-bacnet-c'
-version: '1.2.0'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-bacnet-c.git'
 gitTag: true

--- a/release/device-camera-go.yaml
+++ b/release/device-camera-go.yaml
@@ -1,10 +1,10 @@
 ---
 name: 'device-camera-go'
-version: '1.1.2'
-releaseName: 'geneva'
+version: '1.2.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-camera-go.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-camera-go
@@ -15,4 +15,3 @@ docker:
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-camera-go-arm64
       - docker.io/edgexfoundry/docker-device-camera-go-arm64
-snap: false

--- a/release/device-grove-c.yaml
+++ b/release/device-grove-c.yaml
@@ -1,14 +1,13 @@
 ---
 name: 'device-grove-c'
-version: '1.2.1'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-grove-c.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-grove-c-arm64
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-grove-c-arm64
       - docker.io/edgexfoundry/docker-device-grove-c-arm64
-snap: false

--- a/release/device-modbus-go.yaml
+++ b/release/device-modbus-go.yaml
@@ -1,10 +1,10 @@
 ---
 name: 'device-modbus-go'
-version: '1.2.2'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-modbus-go.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-modbus-go
@@ -15,9 +15,3 @@ docker:
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-modbus-go-arm64
       - docker.io/edgexfoundry/docker-device-modbus-go-arm64
-snap: true
-snapChannels:
-  - channel: 'latest/stable'
-    trackName: 'latest/beta'
-  - channel: 'geneva/stable'
-    trackName: 'latest/beta'

--- a/release/device-mqtt-go.yaml
+++ b/release/device-mqtt-go.yaml
@@ -1,10 +1,10 @@
 ---
 name: 'device-mqtt-go'
-version: '1.2.2'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-mqtt-go.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-mqtt-go
@@ -15,9 +15,3 @@ docker:
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-mqtt-go-arm64
       - docker.io/edgexfoundry/docker-device-mqtt-go-arm64
-snap: true
-snapChannels:
-  - channel: 'latest/stable'
-    trackName: 'latest/beta'
-  - channel: 'geneva/stable'
-    trackName: 'latest/beta'

--- a/release/device-random.yaml
+++ b/release/device-random.yaml
@@ -1,10 +1,10 @@
 ---
 name: 'device-random-go'
-version: '1.2.2'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-random.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-random-go
@@ -15,4 +15,3 @@ docker:
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-random-go-arm64
       - docker.io/edgexfoundry/docker-device-random-go-arm64
-snap: false

--- a/release/device-rest-go.yaml
+++ b/release/device-rest-go.yaml
@@ -1,10 +1,10 @@
 ---
 name: 'device-rest-go'
-version: '1.1.2'
-releaseName: 'geneva'
+version: '1.2.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-rest-go.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-rest-go
@@ -15,4 +15,3 @@ docker:
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-rest-go-arm64
       - docker.io/edgexfoundry/docker-device-rest-go-arm64
-snap: false

--- a/release/device-snmp-go.yaml
+++ b/release/device-snmp-go.yaml
@@ -1,10 +1,10 @@
 ---
 name: 'device-snmp-go'
-version: '1.2.2'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-snmp-go.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-snmp-go
@@ -15,4 +15,3 @@ docker:
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-snmp-go-arm64
       - docker.io/edgexfoundry/docker-device-snmp-go-arm64
-snap: false

--- a/release/device-virtual-go.yaml
+++ b/release/device-virtual-go.yaml
@@ -1,10 +1,10 @@
 ---
 name: 'device-virtual-go'
-version: '1.2.3'
-releaseName: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/device-virtual-go.git'
-gitTag: false
+gitTag: true
 dockerImages: true
 docker:
   - image: nexus3.edgexfoundry.org:10004/docker-device-virtual-go
@@ -15,4 +15,3 @@ docker:
     destination:
       - nexus3.edgexfoundry.org:10002/docker-device-virtual-go-arm64
       - docker.io/edgexfoundry/docker-device-virtual-go-arm64
-snap: false


### PR DESCRIPTION
@iain-anderson , can you look at this release manifest for device services for Hanoi and see how it looks? Pay special attention to the device-service names and version numbers to ensure they're what we want to release with Hanoi.

CC: @lenny-intel , @jpwhitemn 

device-bacnet-c (v1.3.0)
device-camera-go (v1.2.0)
device-grove-c (v1.3.0)
device-modbus-go (v1.3.0)
device-mqtt-go (v1.3.0)
device-random-go (v1.3.0)
device-rest-go (v1.2.0)
device-snmp-go (v1.3.0)
device-virtual-go (v1.3.0)

To be merged Nov 18th pending Device Service WG approval.

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>