### PR TITLE
release(hanoi): Tag blackbox-testing and edgex-taf

### DIFF
--- a/release/blackbox-testing.yaml
+++ b/release/blackbox-testing.yaml
@@ -1,8 +1,8 @@
 ---
 name: 'blackbox-testing'
-version: '1.2.1'
-releaseName: 'geneva'
-releaseStream: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
+releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/blackbox-testing.git'
 gitTag: true
 dockerImages: false

--- a/release/edgex-taf.yaml
+++ b/release/edgex-taf.yaml
@@ -1,8 +1,8 @@
 ---
 name: 'edgex-taf'
-version: '1.2.1'
-releaseName: 'geneva'
-releaseStream: 'geneva'
+version: '1.3.0'
+releaseName: 'hanoi'
+releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/edgex-taf.git'
 gitTag: true
 dockerImages: false


### PR DESCRIPTION
Prepped for merging after Hanoi release.

This will tag the blackbox and taf repos to associate them with Hanoi (1.3.0)

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>