### PR TITLE
release(hanoi): release artifacts for edgex-cli

### DIFF
--- a/release/edgex-cli.yaml
+++ b/release/edgex-cli.yaml
@@ -1,0 +1,14 @@
+---
+  name: 'edgex-cli'
+  version: '1.0.0'
+  releaseName: 'hanoi'
+  releaseStream: 'master'
+  repo: 'https://github.com/edgexfoundry/edgex-cli.git'
+  gitTag: true
+  dockerImages: false
+  gitHubRelease: false
+  gitHubReleaseAssets:
+    - 'https://logs.edgexfoundry.org/production/vex-yul-edgex-jenkins-1/edgexfoundry/edgex-cli/master/39/bin/edgex-cli-linux-amd64-1.0.0.tar.gz'
+    - 'https://logs.edgexfoundry.org/production/vex-yul-edgex-jenkins-1/edgexfoundry/edgex-cli/master/39/bin/edgex-cli-linux-arm64-1.0.0.tar.gz'
+    - 'https://logs.edgexfoundry.org/production/vex-yul-edgex-jenkins-1/edgexfoundry/edgex-cli/master/39/bin/edgex-cli-mac-1.0.0.tar.gz'
+    - 'https://logs.edgexfoundry.org/production/vex-yul-edgex-jenkins-1/edgexfoundry/edgex-cli/master/39/bin/edgex-cli-win-1.0.0.zip' 


### PR DESCRIPTION
This is a bit quirky for a archive artifact release vs a docker image release but I believe this will work and trigger build 39 (which is the next build #) on edgex-cli and create artifacts with version 1.0.0.  It will then release them from those URLs.

If this is too much going on for one PR,  I can break it up into a build/stage release PR then a release.

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>