### PR TITLE
release(hanoi-dot): release device-sdk-c v1.3.1

### DIFF
--- a/release/device-sdk-c.yaml
+++ b/release/device-sdk-c.yaml
@@ -1,8 +1,10 @@
 ---
 name: 'device-sdk-c'
-version: '1.3.0'
+version: '1.3.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: 'e144b802fa1870b274eef210e2a0de0603b8b97f'
 repo: 'https://github.com/edgexfoundry/device-sdk-c.git'
 gitTag: true
 dockerImages: false
+gitHubRelease: false


### PR DESCRIPTION
Take note this uses the new `commitId` recently implemented.

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>