### PR TITLE
release: device services

### DIFF
--- a/release/device-bacnet-c.yaml
+++ b/release/device-bacnet-c.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-bacnet-c'
-version: '1.3.0'
+version: '1.3.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: 'b6e2bc6f8470fc5bf90c10e498cccae2d89cecff'
 repo: 'https://github.com/edgexfoundry/device-bacnet-c.git'
 gitTag: true
 dockerImages: true

--- a/release/device-camera-go.yaml
+++ b/release/device-camera-go.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-camera-go'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: '7c976a927686ede27636f3a9f751618c238eb67e'
 repo: 'https://github.com/edgexfoundry/device-camera-go.git'
 gitTag: true
 dockerImages: true

--- a/release/device-modbus-go.yaml
+++ b/release/device-modbus-go.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-modbus-go'
-version: '1.3.0'
+version: '1.3.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: '9f3888b97fc6b215bf6207a034605e4e0e7d1a95'
 repo: 'https://github.com/edgexfoundry/device-modbus-go.git'
 gitTag: true
 dockerImages: true

--- a/release/device-mqtt-go.yaml
+++ b/release/device-mqtt-go.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-mqtt-go'
-version: '1.3.0'
+version: '1.3.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: 'b247510d13ba8e9fad57040faa04d23d7bfdafc2'
 repo: 'https://github.com/edgexfoundry/device-mqtt-go.git'
 gitTag: true
 dockerImages: true

--- a/release/device-random.yaml
+++ b/release/device-random.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-random-go'
-version: '1.3.0'
+version: '1.3.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: '41f5d722ed384a400e6228adec89c54b28402ec9'
 repo: 'https://github.com/edgexfoundry/device-random.git'
 gitTag: true
 dockerImages: true

--- a/release/device-rest-go.yaml
+++ b/release/device-rest-go.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-rest-go'
-version: '1.2.0'
+version: '1.2.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: '9e4888f50a2a312870744f4f89808877d999d7c6'
 repo: 'https://github.com/edgexfoundry/device-rest-go.git'
 gitTag: true
 dockerImages: true

--- a/release/device-snmp-go.yaml
+++ b/release/device-snmp-go.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-snmp-go'
-version: '1.3.0'
+version: '1.3.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: '2835f428d5bb359d09284af55213ecc07555b5ca'
 repo: 'https://github.com/edgexfoundry/device-snmp-go.git'
 gitTag: true
 dockerImages: true

--- a/release/device-virtual-go.yaml
+++ b/release/device-virtual-go.yaml
@@ -1,8 +1,9 @@
 ---
 name: 'device-virtual-go'
-version: '1.3.0'
+version: '1.3.1'
 releaseName: 'hanoi'
 releaseStream: 'master'
+commitId: 'bdf1cd5a2d4a5f1f1834e794e258934dca5f302b'
 repo: 'https://github.com/edgexfoundry/device-virtual-go.git'
 gitTag: true
 dockerImages: true


### PR DESCRIPTION
We're now ready to go with the dot releases of the device services. 
These all just come from the HEAD of the master branches, versions are as follows:

device-modbus-go  v1.3.1
device-mqtt-go   v1.3.1
device-random  v1.3.1
device-virtual-go v1.3.1
device-snmp-go v1.3.1
device-bacnet-c v1.3.1
device-rest-go v1.2.1
device-camera-go  v1.2.1

Releasing device-grove-c v1.3.1in a different PR, it's not ready right now.

Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>