### PR TITLE
Fix run-time SSL error and build-time error - sync-github-labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /synclabels
 
 COPY . /synclabels/
 
-RUN apk add --update --no-cache git gcc libc-dev libffi-dev openssl-dev
-
 RUN pip install pybuilder==0.11.17
 RUN pyb install_dependencies
 RUN pyb install
@@ -24,5 +22,3 @@ WORKDIR /opt/synclabels
 COPY --from=build-image /synclabels/target/dist/synclabels-*/dist/synclabels-*.tar.gz /opt/synclabels
 
 RUN pip install synclabels-*.tar.gz
-
-CMD echo 'DONE'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,11 +57,15 @@ pipeline {
                                 command += ' --execute'
                             }
                             sh command
-                            archiveArtifacts artifacts: '*.log'
                         }
                     }
                 }
             }
+        }
+    }
+    post {
+        always {
+            archiveArtifacts artifacts: 'sync-github-labels.log', allowEmptyArchive: true
         }
     }
 }

--- a/build.py
+++ b/build.py
@@ -35,7 +35,7 @@ authors = [
 ]
 summary = 'A Python script to synchronize labels for repositories in a GitHub organization'
 url = 'https://github.com/edgexfoundry/cd-management/tree/git-label-sync'
-version = '0.0.6'
+version = '0.0.7'
 default_task = [
     'clean',
     'analyze',

--- a/build.py
+++ b/build.py
@@ -68,7 +68,7 @@ def cyclomatic_complexity(project, logger):
         command.use_argument('-a')
         result = command.run_on_production_source_files(logger)
         if len(result.error_report_lines) > 0:
-            logger.error('Errors while running radon, see {0}'.format(result.error_report_file))
+            logger.error(f'Errors while running radon, see {result.error_report_file}')
         for line in result.report_lines[:-1]:
             logger.debug(line.strip())
         if not result.report_lines:
@@ -77,4 +77,4 @@ def cyclomatic_complexity(project, logger):
         logger.info(average_complexity_line)
 
     except Exception as exception:
-        print('ERROR: unable to execute cyclomatic complexity due to: {}'.format(str(exception)))
+        print(f'Unable to execute cyclomatic complexity due to ERROR: {exception}')

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,6 @@
 coverage
 flake8
+flake8_polyfill
 pypandoc
 unittest-xml-reporting
 mccabe

--- a/src/main/python/synclabels/api.py
+++ b/src/main/python/synclabels/api.py
@@ -52,8 +52,8 @@ class API(GitHubAPI):
         matched_repos = API.match_key_values(repos, regex=regex, **attributes)
         return [
             repo['name']
-                for repo in matched_repos
-                    if repo['name'] not in exclude_repos
+            for repo in matched_repos
+            if repo['name'] not in exclude_repos
         ]
 
     def get_labels(self, repo):

--- a/src/main/python/synclabels/cli.py
+++ b/src/main/python/synclabels/cli.py
@@ -430,7 +430,9 @@ def get_screen_layout():
 
 
 def synchronize(data, shared_data):
-    client = shared_data['client']
+    """ synchronize labels and milestones
+    """
+    client = get_client()
     repo = f"{shared_data['owner']}/{data['repo']}"
 
     client.sync_labels(
@@ -490,7 +492,6 @@ def initiate_multiprocess(client, args, exclude_repos):
         function=synchronize,
         process_data=process_data,
         shared_data={
-            'client': client,
             'source_repo': args.source_repo,
             'labels': labels,
             'milestones': milestones,

--- a/src/main/python/synclabels/cli.py
+++ b/src/main/python/synclabels/cli.py
@@ -371,47 +371,8 @@ def get_screen_layout():
             'regex': r"^INFO: synchronization of labels to repo '.*/(?P<value>.*)' is complete$",
             'table': True
         },
-        'processes': {
-            'position': (33, 2),
-            'text': 'Processes:',
-            'text_color': 245,
-        },
-        'processes_active': {
-            'position': (34, 5),
-            'text': 'Active: 0',
-            'text_color': 245,
-            'color': 14,
-            'regex': r'^mpcurses: number of active processes (?P<value>\d+)$',
-            'effects': [
-                {
-                    'regex': r'^mpcurses: number of active processes 000$',
-                    'color': 7
-                }
-            ],
-        },
-        'processes_queued': {
-            'position': (35, 5),
-            'text': 'Queued: 0',
-            'text_color': 245,
-            'color': 254,
-            'regex': r'^mpcurses: number of queued processes (?P<value>\d+)$',
-            'effects': [
-                {
-                    'regex': r'^mpcurses: number of queued processes 000$',
-                    'color': 7
-                }
-            ],
-        },
-        'processes_complete': {
-            'position': (36, 2),
-            'text': 'Completed: -',
-            'text_color': 245,
-            'color': 254,
-            'keep_count': True,
-            'regex': r'^mpcurses: a process has completed$'
-        },
         'errors': {
-            'position': (34, 28),
+            'position': (33, 3),
             'text': 'Errors: -',
             'text_color': 245,
             'color': 237,
@@ -419,7 +380,7 @@ def get_screen_layout():
             'regex': r'^ERROR.*$'
         },
         'retries': {
-            'position': (35, 27),
+            'position': (34, 2),
             'text': 'Retries: -',
             'text_color': 245,
             'color': 11,

--- a/src/unittest/python/test_api.py
+++ b/src/unittest/python/test_api.py
@@ -421,11 +421,6 @@ class TestApi(unittest.TestCase):
                 'wait_random_min': 10000,
                 'wait_random_max': 20000,
                 'stop_max_attempt_number': 6  
-            }, {
-                'retry_on_exception': client.retry_ratelimit_error,
-                'stop_max_attempt_number': 60,
-                'wait_fixed': 60000
             }
         ]
-        print(client.retries)
-        self.assertEqual(client.retries, expected_retries)
+        self.assertTrue(expected_retries[0] in client.retries)

--- a/src/unittest/python/test_api.py
+++ b/src/unittest/python/test_api.py
@@ -420,7 +420,7 @@ class TestApi(unittest.TestCase):
                 'retry_on_exception': client.retry_connection_error,
                 'wait_random_min': 10000,
                 'wait_random_max': 20000,
-                'stop_max_attempt_number': 6  
+                'stop_max_attempt_number': 6
             }
         ]
         self.assertTrue(expected_retries[0] in client.retries)

--- a/src/unittest/python/test_cli.py
+++ b/src/unittest/python/test_cli.py
@@ -101,8 +101,10 @@ class TestCli(unittest.TestCase):
         # not much to test here
         get_screen_layout()
 
-    def test__synchronize_Should_CallExpected_When_Called(self, *patches):
+    @patch('synclabels.cli.get_client')
+    def test__synchronize_Should_CallExpected_When_Called(self, get_client_patch, *patches):
         client_mock = Mock()
+        get_client_patch.return_value = client_mock
         data = {
             'repo': 'repo1'
         }
@@ -112,8 +114,7 @@ class TestCli(unittest.TestCase):
             'milestones': ['milestone1', 'milestone2'],
             'source_repo': 'source-repo',
             'modified_since': 'modified-since',
-            'noop': False,
-            'client': client_mock
+            'noop': False
         }
         synchronize(data, shared_data)
         client_mock.sync_labels.assert_called_once_with(
@@ -122,12 +123,6 @@ class TestCli(unittest.TestCase):
             'source-repo',
             modified_since='modified-since',
             noop=False)
-        # client_mock.sync_milestones.assert_called_once_with(
-        #     'owner/repo1',
-        #     ['milestone1', 'milestone2'],
-        #     'source-repo',
-        #     modified_since='modified-since',
-        #     noop=False)
 
     @patch('synclabels.cli.MPcurses')
     def test__initiate_multiprocess_Should_CallExpected_When_Called(self, mpcurses_patch, *patches):


### PR DESCRIPTION
- This update fixes a poorly written unit test that is causing the daily build for `git-label-sync` to fail due to an upstream change made in `github3api`.  

[Build 360](https://jenkins.edgexfoundry.org/view/EdgeX%20Foundry%20Project/job/edgexfoundry/job/cd-management/job/git-label-sync/360/)

The upstream change made to `github3api` was to add a retry for `ChunkedEncodingError` exception which has been recently occurring:

[Build 359](https://jenkins.edgexfoundry.org/view/EdgeX%20Foundry%20Project/job/edgexfoundry/job/cd-management/job/git-label-sync/359/)
[Build 357](https://jenkins.edgexfoundry.org/view/EdgeX%20Foundry%20Project/job/edgexfoundry/job/cd-management/job/git-label-sync/357/)

The root cause of the encoding error is not yet known, it seems to be happening intermittently but the retry added to `github3api` should mitigate by enabling the request to be retried allowing for the sync-github-labels job to finish.

Will add a user story to investigate the root cause of the chunk encoding error (incomplete read).

https://stackoverflow.com/questions/49064398/requests-exceptions-chunkedencodingerror-connection-broken-incompleteread0/55921175#55921175

- During debug testing of the issue above, I noticed the CLI was running into the following issue but was retrying and ultimately getting passed it:
```
SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC decryption failed or bad record mac
```
Apparently the SSL error is coming about due to the recent change to `rest3client` to implement the use of Sessions; apparently Sessions do not like reusing the same SSL connection across multiple threads. Thus I updated the CLI so each thread makes its own connection to the GitHub API (which is probably what I should have done in the first place). Not sure why this only came about with request Session vs. no Session. The post below led me onto a solution:
https://stackoverflow.com/questions/3724900/python-ssl-problem-with-multiprocessing

- Cleaned up Dockerfile
- Removed redundant categories in screen layout definition
- Publish logfile as artifact for Jenkins Job
- Add missing build dependency for linting of unit tests
- Fixed linting errors

Functional Testing
- Thoroughly tested using NOOP mode - log attached
[sync-github-labels.log](https://github.com/edgexfoundry/cd-management/files/6024759/sync-github-labels.log)

Fix Issue #127 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>