### PR TITLE
Fix run-time SSL error - prune-github-tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /prunetags
 
 COPY . /prunetags/
 
-RUN apk add --update --no-cache git gcc libc-dev libffi-dev openssl-dev
 RUN pip install pybuilder==0.11.17
 RUN pyb install_dependencies
 RUN pyb install
@@ -23,5 +22,3 @@ WORKDIR /opt/prunetags
 COPY --from=build-image /prunetags/target/dist/prunetags-*/dist/prunetags-*.tar.gz /opt/prunetags
 
 RUN pip install prunetags-*.tar.gz
-
-CMD echo 'DONE'

--- a/build.py
+++ b/build.py
@@ -18,8 +18,6 @@ from pybuilder.core import init
 from pybuilder.core import Author
 from pybuilder.core import task
 from pybuilder.pluginhelper.external_command import ExternalCommandBuilder
-from pybuilder.utils import read_file
-import json
 
 use_plugin('python.core')
 use_plugin('python.unittest')
@@ -27,7 +25,6 @@ use_plugin('python.install_dependencies')
 use_plugin('python.flake8')
 use_plugin('python.coverage')
 use_plugin('python.distutils')
-use_plugin('filter_resources')
 
 name = 'prunetags'
 authors = [
@@ -35,7 +32,7 @@ authors = [
 ]
 summary = 'A Python script that removes old pre-release tags from repos in a GitHub org'
 url = 'https://github.com/edgexfoundry/cd-management/tree/prune-github-tags'
-version = '0.0.4'
+version = '0.0.5'
 default_task = [
     'clean',
     'analyze',
@@ -68,7 +65,7 @@ def cyclomatic_complexity(project, logger):
         command.use_argument('-a')
         result = command.run_on_production_source_files(logger)
         if len(result.error_report_lines) > 0:
-            logger.error('Errors while running radon, see {0}'.format(result.error_report_file))
+            logger.error(f'Errors while running radon, see {result.error_report_file}')
         for line in result.report_lines[:-1]:
             logger.debug(line.strip())
         if not result.report_lines:
@@ -77,4 +74,4 @@ def cyclomatic_complexity(project, logger):
         logger.info(average_complexity_line)
 
     except Exception as exception:
-        print('ERROR: unable to execute cyclomatic complexity due to: {}'.format(str(exception)))
+        print(f'Unable to execute cyclomatic complexity due to ERROR: {exception}')

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,6 @@
 coverage
 flake8
+flake8_polyfill
 pypandoc
 unittest-xml-reporting
 mccabe

--- a/src/main/python/prunetags/cli.py
+++ b/src/main/python/prunetags/cli.py
@@ -344,47 +344,8 @@ def get_screen_layout():
             'regex': r'^INFO: repo .*/(?P<value>.*) has no tags.*$',
             'table': True
         },
-        'processes': {
-            'position': (32, 2),
-            'text': 'Processes:',
-            'text_color': 245,
-        },
-        'processes_active': {
-            'position': (33, 5),
-            'text': 'Active: 0',
-            'text_color': 245,
-            'color': 14,
-            'regex': r'^mpcurses: number of active processes (?P<value>\d+)$',
-            'effects': [
-                {
-                    'regex': r'^mpcurses: number of active processes 000$',
-                    'color': 7
-                }
-            ],
-        },
-        'processes_queued': {
-            'position': (34, 5),
-            'text': 'Queued: 0',
-            'text_color': 245,
-            'color': 254,
-            'regex': r'^mpcurses: number of queued processes (?P<value>\d+)$',
-            'effects': [
-                {
-                    'regex': r'^mpcurses: number of queued processes 000$',
-                    'color': 7
-                }
-            ],
-        },
-        'processes_complete': {
-            'position': (35, 2),
-            'text': 'Completed: -',
-            'text_color': 245,
-            'color': 254,
-            'keep_count': True,
-            'regex': r'^mpcurses: a process has completed$'
-        },
         'errors': {
-            'position': (33, 28),
+            'position': (32, 3),
             'text': 'Errors: -',
             'text_color': 245,
             'color': 237,
@@ -392,7 +353,7 @@ def get_screen_layout():
             'regex': r'^ERROR.*$'
         },
         'retries': {
-            'position': (34, 27),
+            'position': (33, 2),
             'text': 'Retries: -',
             'text_color': 245,
             'color': 11,
@@ -414,32 +375,32 @@ def version_screen_layout(screen_layout):
 
 def remove_prerelease_tags(data, shared_data):
     repo = data['repo']
-    client = shared_data['client']
     noop = shared_data['noop']
+    client = get_client()
     client.remove_prerelease_tags(repo=repo, noop=noop)
     logger.debug(f'processed repo {repo}')
 
 
 def get_prerelease_tags_report(data, shared_data):
     repo = data['repo']
-    client = shared_data['client']
+    client = get_client()
     report = client.get_prerelease_tags_report(repos=[repo])
     return report
 
 
 def remove_version_tags(data, shared_data):
     repo = data['repo']
-    client = shared_data['client']
     noop = shared_data['noop']
     expression = shared_data['version']
+    client = get_client()
     client.remove_version_tags(repo=repo, noop=noop, expression=expression)
     logger.debug(f'processed repo {repo}')
 
 
 def get_version_tags_report(data, shared_data):
     repo = data['repo']
-    client = shared_data['client']
     expression = shared_data['version']
+    client = get_client()
     report = client.get_version_tags_report(repos=[repo], expression=expression)
     return report
 
@@ -451,7 +412,7 @@ def check_result(process_data):
         raise Exception('one or more processes had errors')
 
 
-def initiate_multiprocess(client, function, args, owner, repos):
+def initiate_multiprocess(function, args, owner, repos):
     """ initiate multiprocess execution
     """
     if args.processes == 0 or args.processes > len(repos):
@@ -479,7 +440,6 @@ def initiate_multiprocess(client, function, args, owner, repos):
         function=function,
         process_data=process_data,
         shared_data={
-            'client': client,
             'owner': owner,
             'noop': args.noop,
             'version': args.version
@@ -617,15 +577,15 @@ def main():
             # from the api methods - that's the way it should be
             if args.report:
                 if not args.version:
-                    result = initiate_multiprocess(client, get_prerelease_tags_report, args, owner, repos)
+                    result = initiate_multiprocess(get_prerelease_tags_report, args, owner, repos)
                 else:
-                    result = initiate_multiprocess(client, get_version_tags_report, args, owner, repos)
+                    result = initiate_multiprocess(get_version_tags_report, args, owner, repos)
                 write_report(result, owner)
             else:
                 if not args.version:
-                    initiate_multiprocess(client, remove_prerelease_tags, args, owner, repos)
+                    initiate_multiprocess(remove_prerelease_tags, args, owner, repos)
                 else:
-                    initiate_multiprocess(client, remove_version_tags, args, owner, repos)
+                    initiate_multiprocess(remove_version_tags, args, owner, repos)
 
     except MissingArgumentError as exception:
         parser.print_usage()

--- a/src/unittest/python/test_cli.py
+++ b/src/unittest/python/test_cli.py
@@ -149,25 +149,27 @@ class TestCli(unittest.TestCase):
         result = version_screen_layout(screen_layout)
         self.assertEqual(result, expected)
 
-    def test__remove_prerelease_tags_Should_CallExpected_When_Called(self, *patches):
+    @patch('prunetags.cli.get_client')
+    def test__remove_prerelease_tags_Should_CallExpected_When_Called(self, get_client_patch, *patches):
+        client_mock = Mock()
+        get_client_patch.return_value = client_mock
         data = {
             'repo': 'org1/repo1'
         }
-        client_mock = Mock()
         shared_data = {
-            'client': client_mock,
             'noop': False
         }
         remove_prerelease_tags(data, shared_data)
         client_mock.remove_prerelease_tags.assert_called_once_with(repo='org1/repo1', noop=False)
 
-    def test__get_prerelease_tags_report_Should_CallExpected_When_Called(self, *patches):
+    @patch('prunetags.cli.get_client')
+    def test__get_prerelease_tags_report_Should_CallExpected_When_Called(self, get_client_patch, *patches):
+        client_mock = Mock()
+        get_client_patch.return_value = client_mock
         data = {
             'repo': 'org1/repo1'
         }
-        client_mock = Mock()
         shared_data = {
-            'client': client_mock
         }
         get_prerelease_tags_report(data, shared_data)
         client_mock.get_prerelease_tags_report.assert_called_once_with(repos=['org1/repo1'])
@@ -185,18 +187,16 @@ class TestCli(unittest.TestCase):
     @patch('prunetags.cli.get_screen_layout')
     def test__initiate_multiprocess_Should_CallExpected_When_Called(self, get_screen_layout_patch, mpcurses_patch, datetime_patch, *patches):
         datetime_patch.now.return_value = datetime(2020, 5, 6, 18, 22, 45, 12065)
-        client_mock = Mock()
         function_mock = Mock()
         args = Namespace(org='org1', user=None, execute=True, screen=True, processes=3, include_repos='test_repo', exclude_repos=None, noop=False, version=None)
 
-        initiate_multiprocess(client_mock, function_mock, args, 'org1', ['org1/repo1'])
+        initiate_multiprocess(function_mock, args, 'org1', ['org1/repo1'])
         mpcurses_patch.assert_called_once_with(
             function=function_mock,
             process_data=[
                 {'repo': 'org1/repo1'}
             ],
             shared_data={
-                'client': client_mock,
                 'owner': 'org1',
                 'noop': False,
                 'version': None
@@ -217,18 +217,16 @@ class TestCli(unittest.TestCase):
     @patch('prunetags.cli.version_screen_layout')
     def test__initiate_multiprocess_Should_Modify_Screen_When_Call_With_Version(self, version_screen_layout_patch, get_screen_layout_patch, mpcurses_patch, datetime_patch, *patches):
         datetime_patch.now.return_value = datetime(2020, 5, 6, 18, 22, 45, 12065)
-        client_mock = Mock()
         function_mock = Mock()
         args = Namespace(org='org1', user=None, execute=True, screen=True, processes=3, include_repos='test_repo', exclude_repos=None, noop=False, version='1.1.1')
 
-        initiate_multiprocess(client_mock, function_mock, args, 'org1', ['org1/repo1'])
+        initiate_multiprocess(function_mock, args, 'org1', ['org1/repo1'])
         mpcurses_patch.assert_called_once_with(
             function=function_mock,
             process_data=[
                 {'repo': 'org1/repo1'}
             ],
             shared_data={
-                'client': client_mock,
                 'owner': 'org1',
                 'noop': False,
                 'version': '1.1.1'
@@ -424,26 +422,28 @@ class TestCli(unittest.TestCase):
         main()
         prune_prerelease_tags_patch.assert_not_called()
 
-    def test__remove_version_tags_Should_CallExpected_When_Called(self, *patches):
+    @patch('prunetags.cli.get_client')
+    def test__remove_version_tags_Should_CallExpected_When_Called(self, get_client_patch, *patches):
+        client_mock = Mock()
+        get_client_patch.return_value = client_mock
         data = {
             'repo': 'org1/repo1'
         }
-        client_mock = Mock()
         shared_data = {
-            'client': client_mock,
             'noop': False,
             'version': '<1.1.1'
         }
         remove_version_tags(data, shared_data)
         client_mock.remove_version_tags.assert_called_once_with(repo='org1/repo1', noop=False, expression='<1.1.1')
 
-    def test__get_version_tags_report_Should_CallExpected_When_Called(self, *patches):
+    @patch('prunetags.cli.get_client')
+    def test__get_version_tags_report_Should_CallExpected_When_Called(self, get_client_patch, *patches):
+        client_mock = Mock()
+        get_client_patch.return_value = client_mock
         data = {
             'repo': 'org1/repo1'
         }
-        client_mock = Mock()
         shared_data = {
-            'client': client_mock,
             'version': '<1.1.1'
         }
         get_version_tags_report(data, shared_data)


### PR DESCRIPTION
- Fix runtime SSLerror `SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC decryption failed or bad record mac` caused by recent upstream change to `rest3client` to leverage Sessions. Each process will establish its own connection to GitHub and connections (session) are no longer shared between processes (threads). Note, the script is currently resilient enough to mitigate the SSLerror (via retry) but I prefer to make this change to not have the script retry as it appears to be less efficient and pollutes the logs.  More info on the error: 
https://stackoverflow.com/questions/3724900/python-ssl-problem-with-multiprocessing
- Remove unneeded items in Dockerfile
- Add missing build dependency to properly lint unit tests
- Fix linting errors
- Remove redundant categories in screen layout

Functional Testing
- Thoroughly functionally tested using NOOP - log attached
[prune-github-tags.log](https://github.com/edgexfoundry/cd-management/files/6024718/prune-github-tags.log)

Fixes Issue #126 
Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>