### PR TITLE
Update so each process instantiates its own API connection and leverage updated MPcurses API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,14 @@ RUN mkdir /dockerhub-audit
 
 COPY . /dockerhub-audit/
 
-RUN apk update
-RUN apk add git gcc unzip
-
 WORKDIR /dockerhub-audit
 
-RUN pip install --upgrade pip
 RUN pip install pybuilder==0.11.17
-RUN pyb clean
 RUN pyb install_dependencies
-RUN pyb -X
-RUN pyb publish
+RUN pyb install
+
 
 FROM python:3.6.5-alpine
-
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV TERM xterm-256color
@@ -30,5 +24,3 @@ WORKDIR /opt/dockerhub-audit
 COPY --from=build-image /dockerhub-audit/target/dist/dockerhub-audit-*/dist/dockerhub-audit-*.tar.gz /opt/dockerhub-audit
 
 RUN pip install dockerhub-audit-*.tar.gz
-
-CMD echo 'DONE'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+[![build-status](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/job/dockerhub-audit/badge/icon)](https://jenkins.edgexfoundry.org/job/edgexfoundry/job/cd-management/job/dockerhub-audit)
 
-# dockerhub-audit
+# cd-management/dockerhub-audit
 
 ## Summary
 
@@ -22,7 +23,6 @@ optional arguments:
   --dockerhub-host-api DOCKERHUB_HOST_API
                         hub.docker.com host API
   --csv                 write jobs to CSV file
-  --noop                execute in NOOP mode (DRY RUN)
   --procs PROCESSES     number of concurrent processes to execute
   --screen              visualize script execution using a curses screen
 ```
@@ -46,7 +46,6 @@ docker container run \
 -it \
 -e http_proxy \
 -e https_proxy \
- -e TERM='xterm-256color' \
 dockerhub-audit:latest \
 /bin/sh
 ```

--- a/build.py
+++ b/build.py
@@ -3,8 +3,6 @@ from pybuilder.core import init
 from pybuilder.core import Author
 from pybuilder.core import task
 from pybuilder.pluginhelper.external_command import ExternalCommandBuilder
-from pybuilder.utils import read_file
-import json
 
 use_plugin('python.core')
 use_plugin('python.unittest')
@@ -12,20 +10,17 @@ use_plugin('python.install_dependencies')
 use_plugin('python.flake8')
 use_plugin('python.coverage')
 use_plugin('python.distutils')
-use_plugin('filter_resources')
 
 name = 'dockerhub-audit'
 authors = [
-    Author('Bill Mahoney', 'bill.mahoney@intel.com')
-]
+    Author('Bill Mahoney', 'bill.mahoney@intel.com')]
 summary = 'A Python script that audits all EdgeX Foundry Dockerhub images with a focus is on staleness and relevency.'
-version = '0.0.1'
+version = '0.0.2'
 default_task = [
     'clean',
     'analyze',
     'cyclomatic_complexity',
-    'package'
-]
+    'package']
 
 
 @init
@@ -51,7 +46,7 @@ def cyclomatic_complexity(project, logger):
         command.use_argument('-a')
         result = command.run_on_production_source_files(logger)
         if len(result.error_report_lines) > 0:
-            logger.error('Errors while running radon, see {0}'.format(result.error_report_file))
+            logger.error(f'Errors while running radon, see {result.error_report_file}')
         for line in result.report_lines[:-1]:
             logger.debug(line.strip())
         if not result.report_lines:
@@ -60,4 +55,4 @@ def cyclomatic_complexity(project, logger):
         logger.info(average_complexity_line)
 
     except Exception as exception:
-        print('Unable to execute cyclomatic complexity due to ERROR: {}'.format(str(exception)))
+        print(f'Unable to execute cyclomatic complexity due to ERROR: {exception}')

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,6 @@
 coverage
 flake8
+flake8_polyfill
 mccabe
 mock
 radon

--- a/src/main/python/dha/cli.py
+++ b/src/main/python/dha/cli.py
@@ -214,7 +214,6 @@ def filter_image_list(image_dict_list):
 
 def filter_tag_list(tag_dict_list):
     # Scrape out the results from the the MP work:
-    utc = pytz.UTC
     just_tags_list = []
     for item in tag_dict_list:
         result = item.get('result')
@@ -222,21 +221,6 @@ def filter_tag_list(tag_dict_list):
             raise ValueError(f"repository {item['name']} is missing result")
         just_tags_list.extend(item['result'])
 
-    for tag in just_tags_list:
-        tag.pop("last_updater", None)
-        tag.pop("v2", None)
-        tag.pop("id", None)
-        tag.pop("creator", None)
-        tag.pop("image_id", None)
-        tag.pop("repository", None)
-        tag['architecture'] = tag['images'][0]['architecture']
-        tag['os'] = tag['images'][0]['os']
-        tag.pop("images", None)
-        tag['tag_name'] = tag['name']
-        tag.pop('name', None)
-        tag['size_in_MB'] = round(tag['full_size'] / 1024 / 1024, 2)
-        tag.pop('full_size', None)
-        tag['days_since_update'] = (utc.localize(datetime.utcnow()) - dateutil.parser.isoparse(tag['last_updated'])).days
     return just_tags_list
 
 
@@ -275,6 +259,7 @@ def get_all_tags(function, args, image_dict_list):
 
 
 def get_tags(image, shared_data):
+    utc = pytz.UTC
     args = shared_data['args']
     client = get_dockerhub_client(args.dockerhub_host_api)
     image_tags_dict_list = []
@@ -285,8 +270,23 @@ def get_tags(image, shared_data):
         tag['repo_name'] = image['name']
         tag['repo_star_count'] = image['star_count']
         tag['repo_pull_count'] = image['pull_count']
+        tag.pop("last_updater", None)
+        tag.pop("v2", None)
+        tag.pop("id", None)
+        tag.pop("creator", None)
+        tag.pop("image_id", None)
+        tag.pop("repository", None)
+        tag['architecture'] = tag['images'][0]['architecture']
+        tag['os'] = tag['images'][0]['os']
+        tag.pop("images", None)
+        tag['tag_name'] = tag['name']
+        tag.pop('name', None)
+        tag['size_in_MB'] = round(tag['full_size'] / 1024 / 1024, 2)
+        tag.pop('full_size', None)
+        tag['days_since_update'] = (utc.localize(datetime.utcnow()) - dateutil.parser.isoparse(tag['last_updated'])).days
         image_tags_dict_list.append(tag)
-        logger.debug(f"Tag Processed {image['name']}:{tag['name']}")
+
+        logger.debug(f"Tag Processed {image['name']}:{tag['tag_name']}")
     return image_tags_dict_list
 
 

--- a/src/unittest/python/test_cli.py
+++ b/src/unittest/python/test_cli.py
@@ -174,48 +174,49 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(result, expected)
 
     @patch('dha.cli.check_result')
-    @patch('dha.cli.execute')
+    @patch('dha.cli.MPcurses')
     def test__get_all_tags_Should_CallExpected_When_Called_Mp(
             self,
             execute_patch,
             check_result_patch,
             *patches):
-        dockerhub_client = Mock()
         get_tags_mock = Mock()
         args = Mock()
         args.processes = 10
         image_dict_list = MagicMock()
         image_dict_list.len.return_value = 5
-        get_all_tags(dockerhub_client, get_tags_mock, args, image_dict_list)
+        get_all_tags(get_tags_mock, args, image_dict_list)
         check_result_patch.assert_called_once()
 
     @patch('dha.cli.check_result')
-    @patch('dha.cli.execute')
+    @patch('dha.cli.MPcurses')
     def test__get_all_tags_Should_CallExpected_When_Called_Sp(
             self,
             execute_patch,
             check_result_patch,
             *patches):
-        dockerhub_client = Mock()
         get_tags_mock = Mock()
         args = Mock()
         args.processes = 1
         image_dict_list = MagicMock()
         image_dict_list.len.return_value = 5
-        get_all_tags(dockerhub_client, get_tags_mock, args, image_dict_list)
+        get_all_tags(get_tags_mock, args, image_dict_list)
         assert not check_result_patch.b.called
 
+    @patch('dha.cli.get_dockerhub_client')
     @patch('dha.cli.logger')
     def test__get_tags_Should_CallExpected_When_Called_(
             self,
             logger_patch,
+            get_dockerhub_client_patch,
             *patches):
         get_return = {
             "count": "mock_return",
             "results": [{
                 "a": "b",
                 "star_count": 5,
-                "pull_count": 4
+                "pull_count": 4,
+                "name": "nero"
             }]
         }
         image = {
@@ -224,9 +225,10 @@ class TestCLI(unittest.TestCase):
             "pull_count": 55
         }
         shared_data = {}
-        shared_data['client'] = Mock()
+        client_mock = Mock()
+        client_mock.get.return_value = get_return
+        get_dockerhub_client_patch.return_value = client_mock
         shared_data['args'] = Mock()
         shared_data['image_tags_dict_list'] = Mock()
-        shared_data['client'].get.return_value = get_return
         get_tags(image, shared_data)
         self.assertEqual(logger_patch.debug.call_count, 2)

--- a/src/unittest/python/test_cli.py
+++ b/src/unittest/python/test_cli.py
@@ -149,23 +149,7 @@ class TestCLI(unittest.TestCase):
                                                'last_updated': '2017-10-22T12:07:02.964046Z'
                                                }],
                    }]
-        expected = [{'a': 'here',
-                     'architecture': "amd64",
-                     'os': "Linux",
-                     'tag_name': 'image1',
-                     'size_in_MB': 45.42,
-                     'last_updated': '2017-10-24T12:07:02.964046Z',
-                     'days_since_update': 1002
-                     },
-                    {'b': 'far',
-                     'architecture': "arm64",
-                     'os': "Windows",
-                     'tag_name': 'image2',
-                     'size_in_MB': 25.49,
-                     'days_since_update': 1004,
-                     'last_updated': '2017-10-22T12:07:02.964046Z'
-                     }
-                    ]
+        expected = [{'creator': 'bob', 'a': 'here', 'images': [{'architecture': 'amd64', 'os': 'Linux'}], 'name': 'image1', 'full_size': 47623330, 'last_updated': '2017-10-24T12:07:02.964046Z'}, {'repository': 'go', 'b': 'far', 'images': [{'architecture': 'arm64', 'os': 'Windows'}], 'name': 'image2', 'full_size': 26727650, 'last_updated': '2017-10-22T12:07:02.964046Z'}]
         result = filter_tag_list(images)
         self.maxDiff = None
         print(result)
@@ -203,6 +187,7 @@ class TestCLI(unittest.TestCase):
         get_all_tags(get_tags_mock, args, image_dict_list)
         assert not check_result_patch.b.called
 
+    # @unittest.skip('skip')
     @patch('dha.cli.get_dockerhub_client')
     @patch('dha.cli.logger')
     def test__get_tags_Should_CallExpected_When_Called_(
@@ -216,7 +201,10 @@ class TestCLI(unittest.TestCase):
                 "a": "b",
                 "star_count": 5,
                 "pull_count": 4,
-                "name": "nero"
+                "name": "nero",
+                'images': [{"architecture": "amd64", "os": "Linux"}],
+                'full_size': 47623330,
+                'last_updated': '2017-10-24T12:07:02.964046Z'
             }]
         }
         image = {


### PR DESCRIPTION
- update spawned processes to make their own connection to DockerHub API - mitigate request Session `SSLerror`
- update to use current MPcurses API
- add missing flake dependency to enable proper linting of unit tests
- add status badge to readme
- remove unneeded commands from Dockerfile
- remove NOOP argument as it was not being used/required
- fix issue @bill-mahoney reported regarding MPcurses concurrency limitation
- add retry resiliency when encountering  `HTTPError: 429 Client Error: Too Many Requests for url`

Fixes #128 

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>