### PR TITLE
Update github3api paging and mpcurses colwidth changes

### DIFF
--- a/build.py
+++ b/build.py
@@ -31,7 +31,7 @@ name = 'prunetags'
 authors = [Author('Emilio Reyes', 'emilio.reyes@intel.com')]
 summary = 'A Python script that removes old pre-release tags from repos in a GitHub org'
 url = 'https://github.com/edgexfoundry/cd-management/tree/prune-github-tags'
-version = '0.0.7'
+version = '0.0.8'
 default_task = [
     'clean',
     'analyze',

--- a/src/main/python/prunetags/api.py
+++ b/src/main/python/prunetags/api.py
@@ -62,13 +62,14 @@ class API(GitHubAPI):
         """
         if not branch:
             branch = 'master'
-        for commit in self.get(f'/repos/{repo}/commits?sha={branch}', _get='page'):
-            commit_sha = commit['sha']
-            tag = API.lookup_tag(tags=tags, sha=commit_sha)
-            if tag:
-                version = API.get_version(name=tag['name'])
-                if version:
-                    return (version, commit_sha)
+        for page in self.get(f'/repos/{repo}/commits?sha={branch}', _get='page'):
+            for commit in page:
+                commit_sha = commit['sha']
+                tag = API.lookup_tag(tags=tags, sha=commit_sha)
+                if tag:
+                    version = API.get_version(name=tag['name'])
+                    if version:
+                        return (version, commit_sha)
         return (None, None)
 
     def get_prerelease_tags(self, repo=None, branch=None):

--- a/src/main/python/prunetags/cli.py
+++ b/src/main/python/prunetags/cli.py
@@ -177,7 +177,7 @@ def get_screen_layout():
             'text': 'Include-Repos: -',
             'text_color': 245,
             'color': 254,
-            'width': 48,
+            'length': 48,
             'regex': "^'include_repos' is '(?P<value>.*)'$"
         },
         'exclude_repos': {
@@ -185,7 +185,7 @@ def get_screen_layout():
             'text': 'Exclude-Repos: -',
             'text_color': 245,
             'color': 254,
-            'width': 48,
+            'length': 48,
             'regex': "^'exclude_repos' is '(?P<value>.*)'$"
         },
         'repos': {
@@ -301,7 +301,7 @@ def get_screen_layout():
             'text': '--------------',
             'text_color': 242,
             'color': 15,
-            'width': 14,
+            'length': 14,
             'right_justify': True,
             'regex': r'^repo .* latest tag version is (?P<value>.*)$',
             'table': True
@@ -310,7 +310,7 @@ def get_screen_layout():
             'position': (10, 25),
             'text': '',
             'color': 242,
-            'width': 30,
+            'length': 30,
             'regex': r"^'repo' is '.*/(?P<value>.*)'$",
             'table': True
         },
@@ -318,7 +318,7 @@ def get_screen_layout():
             'position': (10, 25),
             'text': '',
             'color': 14,
-            'width': 30,
+            'length': 30,
             'regex': r'^INFO: removing (prerelease|version) tags from repo .*/(?P<value>.*)$',
             'table': True
         },
@@ -326,7 +326,7 @@ def get_screen_layout():
             'position': (10, 25),
             'text': '',
             'color': 15,
-            'width': 30,
+            'length': 30,
             'regex': r'^removed (prerelease|version) tags from repo .*/(?P<value>.*)$',
             'table': True
         },
@@ -335,7 +335,7 @@ def get_screen_layout():
             'text': '',
             # 'color': 242,
             'color': 3,
-            'width': 30,
+            'length': 30,
             'regex': r'^INFO: repo .*/(?P<value>.*) has no tags.*$',
             'table': True
         },

--- a/src/unittest/python/test_api.py
+++ b/src/unittest/python/test_api.py
@@ -111,9 +111,7 @@ class TestApi(unittest.TestCase):
     @patch('prunetags.API.get')
     def test__get_latest_version_Should_CallAndReturnExpected_When_Called(self, get_patch, lookup_tag_patch, get_version_patch, *patches):
         get_patch.return_value = [
-            {'sha': '-sha1-'},
-            {'sha': '-sha2-'},
-            {'sha': '-sha3-'}
+            [{'sha': '-sha1-'}, {'sha': '-sha2-'}, {'sha': '-sha3-'}]
         ]
         client = API(bearer_token='bearer-token')
         tags = ['tag1', 'tag2']
@@ -127,9 +125,7 @@ class TestApi(unittest.TestCase):
     @patch('prunetags.API.get')
     def test__get_latest_version_Should_ReturnExpected_When_NoTagFound(self, get_patch, lookup_tag_patch, get_version_patch, *patches):
         get_patch.return_value = [
-            {'sha': '-sha1-'},
-            {'sha': '-sha2-'},
-            {'sha': '-sha3-'}
+            [{'sha': '-sha1-'}, {'sha': '-sha2-'}, {'sha': '-sha3-'}]
         ]
         lookup_tag_patch.side_effect = [
             None,


### PR DESCRIPTION
Update to accommodate for a couple of upstream (dependency) changes:
- github3api paging changes - paging method for github3api changed
- mpcurses length changes - mpcurses renamed category width parameter to length

Signed-off-by: Emilio Reyes <emilio.reyes@intel.com>