### PR TITLE
feat: add changelog-generator

### DIFF
--- a/.chglog-default/CHANGELOG.tpl.md
+++ b/.chglog-default/CHANGELOG.tpl.md
@@ -1,0 +1,36 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }} ([#{{ .Hash.Short }}]({{$.Info.RepositoryURL}}/commits/{{.Hash.Short}}))
+{{ range .Notes -}}
+{{ if contains .Title "BREAKING CHANGE" -}}
+{{indent "```" 4}}
+{{indent .Title 4}}:
+{{indent .Body 4}}
+{{indent "```" 4}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog-default/config.yml
+++ b/.chglog-default/config.yml
@@ -1,0 +1,44 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    sort_by: Custom
+    title_order:
+        - feat
+        - update
+        - perf
+        - fix
+        - refactor
+        - docs
+        - build
+        - chore
+        - ci
+    title_maps:
+      feat: Features ✨
+      fix: Bug Fixes 🐛
+      perf: Performance Improvements ⚡
+      refactor: Code Refactoring ♻
+      update: Updates 🔄
+      build: Build 👷
+      ci: Continuous Integration 🔄
+      chore: Other changes
+      docs: Documentation 📖
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,60 @@
+//
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+def jobs = []
+
+def generateStage(job) {
+    return {    
+        def clone_url = job.split('"clone_url": "')[1].replaceAll('",','')
+        def repo_url = clone_url.split('\\.git')[0]
+        def name = repo_url.split('edgexfoundry\\/')[1]
+        sh "git clone ${clone_url}"
+        sh "mkdir -p ${name}/.chglog && cp --no-clobber -r .chglog-default/. ${name}/.chglog"
+        docker.image('quay.io/git-chglog/git-chglog').inside('--entrypoint=""'){
+            dir("${name}"){
+                sh "git tag | grep dev | xargs -n 1 -i% git tag -d %"
+                sh "/usr/local/bin/git-chglog --repository-url ${repo_url} --next-tag x.y.z --sort semver --output ${name}-CHANGELOG.md || /usr/local/bin/git-chglog --next-tag x.y.z --output ${name}-CHANGELOG.md"
+            }
+        }
+        archiveArtifacts allowEmptyArchive: true, artifacts: "${name}/${name}-CHANGELOG.md"
+    }
+}
+
+pipeline {
+    agent {
+        label 'centos7-docker-4c-2g'
+    }
+    options {
+        timestamps()
+    }
+
+    triggers {
+        cron '@weekly'
+    }
+    stages {
+        stage('Parallel Changelog Generator'){
+            steps {
+                script {
+                    jobs = sh (
+                        script: 'curl -i "https://api.github.com/search/repositories?q=user:edgexfoundry+archived:false&per_page=200" | grep clone_url',
+                        returnStdout: true).trim().split("\n")
+                    parallel jobs.collectEntries {[(it.split('edgexfoundry/')[1].split('.git')[0]) : generateStage(it)]}
+                }
+            }
+        }
+    }
+}
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,12 +44,24 @@ pipeline {
     triggers {
         cron '@weekly'
     }
+    parameters {
+        string(
+            name: 'Query',
+            defaultValue: '',
+            description: 
+            '''Search query to use to select which repositories to generate a changelog for. 
+            <br>
+            <br>Default: Leave blank, all un-archived repositories within the edgexfoundry Github organization will be selected.
+            <br>Example: "device", all repositories with *device* in title will be selected.
+            '''
+        )
+    }
     stages {
         stage('Parallel Changelog Generator'){
             steps {
                 script {
                     jobs = sh (
-                        script: 'curl -i "https://api.github.com/search/repositories?q=user:edgexfoundry+archived:false&per_page=200" | grep clone_url',
+                        script: "curl -i \"https://api.github.com/search/repositories?q=user:edgexfoundry+archived:false+${params.Query}&per_page=200\" | grep clone_url",
                         returnStdout: true).trim().split("\n")
                     parallel jobs.collectEntries {[(it.split('edgexfoundry/')[1].split('.git')[0]) : generateStage(it)]}
                 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # cd-management
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr-raw/edgexfoundry/cd-management)](https://github.com/edgexfoundry/cd-management/pulls) [![GitHub Contributors](https://img.shields.io/github/contributors/edgexfoundry/cd-management)](https://github.com/edgexfoundry/cd-management/contributors) [![GitHub Committers](https://img.shields.io/badge/team-committers-green)](https://github.com/orgs/edgexfoundry/teams/devops-core-team/members) [![GitHub Commit Activity](https://img.shields.io/github/commit-activity/m/edgexfoundry/cd-management)](https://github.com/edgexfoundry/cd-management/commits)
 
+Periodic Jenkins job to automatically generate CHANGELOG.md files each EdgeX Foundry repository.
+
+- Iterates through **non-archived** repositories
+- Clones each repository in parallel.
+- Copies CHANGELOG.tpl.md and config.yml to each repository (If one already exists in the target repository it will not overwrite it).
+- Locally deletes `dev` tags.
+- Generates and archives the CHANGELOG.md for each repository.
+
+Contributing community members can download this changelog for their repository and use it as a basis for a PR to update the changelog prior to release.
+
+This job utilizes [git-chglog](https://github.com/git-chglog/git-chglog) for CHANGELOG.md generation.


### PR DESCRIPTION
Periodic Jenkins job to automatically generate CHANGELOG.md files each EdgeX Foundry repository.

- Iterates through **non-archived** repositories
- Clones each repository in parallel.
- Copies CHANGELOG.tpl.md and config.yml to each repository (If one already exists in the target repository it will not overwrite it).
- Locally deletes `dev` tags.
- Generates and archives the CHANGELOG.md for each repository.

Contributing community members can download this changelog for their repository and use it as a basis for a PR to update the changelog prior to release.

This job utilizes [git-chglog](https://github.com/git-chglog/git-chglog) for CHANGELOG.md generation.

Pipeline View:
![image](https://user-images.githubusercontent.com/61600932/116943211-f63fa400-ac27-11eb-8105-7173e8e7de08.png)

Functional Testing / Sandbox Links
[Build Console](https://jenkins.edgexfoundry.org/sandbox/job/Functional-Testing/job/changelog-generator-scm/24/)
[Build Artifacts](https://jenkins.edgexfoundry.org/sandbox/job/Functional-Testing/job/changelog-generator-scm/24/artifact/)

Custom Query: <blank>  (Do all unarchived repos) - [Pipeline](https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/Functional-Testing%2Fchangelog-generator-scm/detail/changelog-generator-scm/26/pipeline)
Custom Query: "device" (Do all device services) - [Pipeline](https://jenkins.edgexfoundry.org/sandbox/blue/organizations/jenkins/Functional-Testing%2Fchangelog-generator-scm/detail/changelog-generator-scm/27/pipeline)



[Sample Output](https://github.com/bill-mahoney/changelog-automation/tree/main/Samples)


![image](https://user-images.githubusercontent.com/61600932/117212027-a0493880-adae-11eb-96f7-966f9b9c58fd.png)


Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>