### PR TITLE
release(ireland): go-mod-messaging 2.0.1

### DIFF
--- a/release/go-mod-messaging.yaml
+++ b/release/go-mod-messaging.yaml
@@ -4,6 +4,6 @@ version: '2.0.1'
 releaseName: 'ireland'
 releaseStream: 'master'
 repo: 'https://github.com/edgexfoundry/go-mod-messaging.git'
-commitId: '19fd5df1057e42ff650d61883e5f516c89e678f7'
+commitId: '462d2b631b3a66b5ccca44d94490a8fbffa36db5'
 gitTag: true
 dockerImages: false


### PR DESCRIPTION
Signed-off-by: Bill Mahoney <bill.mahoney@intel.com>