### PR TITLE
fix: remove old github ssh key from known hosts to fix host mismatch error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,18 @@ pipeline {
         RELEASE_DOCKER_SETTINGS = 'cd-management-settings'
     }
     stages {
+        stage('SSH Fix') {
+            steps {
+                // Remove existing ssh-rsa key for github.com in known hosts to fix IP mismatch
+                sh '''
+                grep -v github.com /etc/ssh/ssh_known_hosts > /tmp/ssh_known_hosts
+                if [ -e /tmp/ssh_known_hosts ]; then
+                    sudo mv /tmp/ssh_known_hosts /etc/ssh/ssh_known_hosts
+                fi
+                '''
+            }
+        }
+
         stage('Lint YAML files') {
             agent {
                 docker {


### PR DESCRIPTION
The ssh key for GitHub has changed and the packer images have an old key.

https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/

This PR will just remove the key and let ssh pull the correct one.

This will remove this message in the logs:

```
08:42:15  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
08:42:15  @       WARNING: POSSIBLE DNS SPOOFING DETECTED!          @
08:42:15  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
08:42:15  The RSA host key for github.com has changed,
08:42:15  and the key for the corresponding IP address 140.82.114.3
08:42:15  is unknown. This could either mean that
08:42:15  DNS SPOOFING is happening or the IP address for the host
08:42:15  and its host key have changed at the same time.
08:42:15  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
08:42:15  @    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
08:42:15  @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
08:42:15  IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
08:42:15  Someone could be eavesdropping on you right now (man-in-the-middle attack)!
08:42:15  It is also possible that a host key has just been changed.
08:42:15  The fingerprint for the RSA key sent by the remote host is
08:42:15  SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s.
08:42:15  Please contact your system administrator.
08:42:15  Add correct host key in /dev/null to get rid of this message.
08:42:15  Offending RSA key in /etc/ssh/ssh_known_hosts:1
08:42:15  Password authentication is disabled to avoid man-in-the-middle attacks.
08:42:15  Keyboard-interactive authentication is disabled to avoid man-in-the-middle attacks.
08:42:15  fatal: Remote branch minnesota not found in upstream origin
```

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->