### PR TITLE
fix: remove old github ssh key from known hosts to fix host mismatch error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,18 @@ pipeline {
         RELEASE_DOCKER_SETTINGS = 'cd-management-settings'
     }
     stages {
+        stage('SSH Fix') {
+            steps {
+                // Remove existing ssh-rsa key for github.com in known hosts to fix IP mismatch
+                sh '''
+                grep -v github.com /etc/ssh/ssh_known_hosts > /tmp/ssh_known_hosts
+                if [ -e /tmp/ssh_known_hosts ]; then
+                    sudo mv /tmp/ssh_known_hosts /etc/ssh/ssh_known_hosts
+                fi
+                '''
+            }
+        }
+
         stage('Lint YAML files') {
             agent {
                 docker {


### PR DESCRIPTION
Same fix as #361 is needed on the LTS branch.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->